### PR TITLE
docs: v2 debate engine design + technical spec (Round 5 — simplified)

### DIFF
--- a/docs/adr/0004-flat-config-mvp.md
+++ b/docs/adr/0004-flat-config-mvp.md
@@ -1,6 +1,8 @@
 # ADR-0004: Flat single-file config for MVP (defer directory split)
 
-**Status:** Proposed.
+**Status:** Accepted. Retained in v2 after Round 5 simplification reverted the [ADR-0007](0007-classifier-selects-per-type-profile.md) per-type split.
+
+v1 shipped with `defaults/default.yaml`. v2 Round 4 briefly replaced this with three type-specific profiles (`synthesis.yaml`, `vote.yaml`, `factual.yaml`) plus a separate `classifier.yaml` per ADR-0007, but the Round 5 simplification (2026-04-21) reverted to a single `defaults/default.yaml` — ADR-0007 is now superseded. The "extension path" toward a directory layout (`profiles/`, `experts/`, `judges/`) sketched here remains a possible future evolution if configuration complexity genuinely grows; v2's single-profile shape made the directory split unnecessary.
 
 ## Context
 

--- a/docs/adr/0006-synthesis-only-judge.md
+++ b/docs/adr/0006-synthesis-only-judge.md
@@ -1,6 +1,10 @@
 # ADR-0006: Judge synthesizes only — no debate rounds at MVP
 
-**Status:** Proposed.
+**Status:** Superseded by [ADR-0008 (debate rounds with anonymization + nonce injection)](0008-debate-rounds-anonymization-injection.md).
+
+v1 shipped with single-pass synthesis. v2 introduces multi-round debate (K≥1, default K=2) with blind round 1 + peer-aware round 2, stable anonymization labels, and a per-session nonce on prompt fences. Rounds count comes from the `rounds` field in the single `defaults/default.yaml` profile; there is no `--rounds` CLI flag.
+
+v2 also removes the judge role entirely — the Round 5 simplification (see `docs/design/v2.md` D15) replaced judge-driven synthesis with expert-cast voting, where the winning expert's R2 text is returned verbatim. ADR-0006's "judge synthesizes only" decision is thus doubly reshaped: MVP had the judge; v2 replaces the judge with voting.
 
 ## Context
 

--- a/docs/adr/0007-classifier-selects-per-type-profile.md
+++ b/docs/adr/0007-classifier-selects-per-type-profile.md
@@ -1,0 +1,55 @@
+# ADR-0007: LLM classifier selects per-type profile
+
+**Status:** **Superseded** by v2 simplification (Round 5, 2026-04-21). v2 reframed to a unified debate+vote flow; classifier dropped entirely. See `docs/design/v2.md` Round 5 status banner for rationale: the classifier existed to branch between synthesis / vote / factual flows, but all three flows were consolidated into a single debate+vote path when structured machine-readable output was confirmed out-of-scope for v2. With one flow, there is no routing decision for the classifier to make.
+
+This ADR is retained for historical record — the Round 4 reasoning remains valid within its premises (three-flow architecture). The citations in this file (Xiong et al 2024, Wang et al 2022) remain relevant to any future v3 reintroduction of classifier routing.
+
+## Context
+
+v2 adds three distinct flows — synthesis, vote, factual — each with a different round structure, aggregation shape, and judge behavior. Asking the operator to pick the right mode on every invocation is a footgun: the shape of a question often implies its type (open-ended vs discrete-choice vs single-fact), and mistyped mode selection produces silently wrong flows.
+
+Earlier drafts considered a single master profile with mode-specific fields — `debate:`, `voting:`, `factual:` — guarded by a `mode:` key. This created an "ignored fields" problem (each run uses ~⅓ of the profile and silently skips the rest) and an authority question (when mode and config disagree, who wins?).
+
+Alternatives:
+
+- **`--mode synthesis|vote|factual` CLI flag** — puts the type choice in shell history; invisible to `verdict.json` audit; routes the footgun through a different hole.
+- **Heuristic classifier** (regex on question shape) — brittle; many false positives and negatives.
+- **Single master profile with mode-specific blocks** — rejected for ignored-fields + authority ambiguity.
+- **LLM classifier + type-pure profiles** — chosen.
+
+## Decision
+
+Before flow selection, a lightweight LLM call (Haiku, `confidence ≥ 0.75` threshold) reads the question and outputs `{"type": "synthesis"|"vote"|"factual", "confidence": 0.N, "rationale": "..."}`. The orchestrator looks up the matching profile by name — by default `defaults/<type>.yaml` — and runs that profile's flow. Three profiles ship: `synthesis.yaml`, `vote.yaml`, `factual.yaml`, plus a separate `classifier.yaml` for the classifier call itself.
+
+Each profile has a type-pure YAML schema with no "mode-specific ignored fields." Profile name ≡ type.
+
+**Bypass:**
+- `--profile <file>` skips the classifier and loads the named profile directly (non-interactive runs, CI, debugging). Custom profile directories (`--profile-dir <dir>`) were evaluated but dropped on YAGNI grounds during Round 4 review — operators who want custom profiles edit `./.council/<type>.yaml` (v1 loader precedence picks these up transparently) or pass `--profile <file>` per-run.
+
+**Verbose mode (`-v`)** prints the classifier's `type`/`confidence`/`rationale` to stderr before debate starts so the operator can Ctrl+C on obviously wrong classification. This is the only classifier-output safety gate — no regex sanity check and no user-confirmation prompt (both considered and dropped on YAGNI grounds in Round 4).
+
+**Retry policy:** no retry on the classifier call (output is lightweight; failure means re-run whole session after fixing). On timeout → exit 4 `classifier_timeout`. On confidence below threshold → exit 4 `classifier_unclear`. Default `classifier.timeout: 30s`.
+
+## Consequences
+
+- **(+)** Zero hidden mode state — the profile name on disk matches the flow that ran, visible in the session folder and `verdict.json`.
+- **(+)** Each profile's YAML is self-documenting about what it runs — no "this field is ignored in this mode" footnote.
+- **(+)** Adding a new type in v3 (e.g., `ranking`) = new file + classifier prompt update; zero refactor of existing profiles.
+- **(+)** Bypass mechanism (`--profile`) keeps the orchestrator usable in CI / scripted contexts where the type is known in advance.
+- **(−)** Every invocation pays one Haiku LLM call (~1–2s on a cheap model).
+- **(−)** Wrong classification → wrong flow; mitigated by `-v` preview + `0.75` confidence threshold + exit 4 on low confidence.
+- **(−)** Classifier and debate packages cannot share state (they run sequentially, pre-debate vs debate) — codified as `pkg/classifier/` separate from `pkg/debate/` (see `docs/design/v2.md` D12).
+
+## Compliance
+
+- **F10** (fitness function): `jq -e '.classifier.type | IN("synthesis","vote","factual")' verdict.json` passes — classifier output schema uses `type` key, not `mode`.
+- Default `confidence_threshold: 0.75` in `defaults/classifier.yaml`; operators can raise but not silently lower without an override flag (future).
+
+## Research
+
+- Xiong et al 2024 — LLM self-reported confidence is poorly calibrated in absolute terms. Mitigation: strict-JSON response (malformed → fail loud), threshold 0.75, operator-visible preview at `-v`.
+- Wang et al 2022 (self-consistency) — v3 upgrade path if the 0.75 threshold proves too leaky.
+
+## Supersedes
+
+- [ADR-0004 — flat single-file config for MVP](0004-flat-config-mvp.md). v2 replaces the master `default.yaml` with three type-specific profiles + a classifier config. The directory-layout extension sketched in ADR-0004 was not taken — classifier-driven per-type selection made the shared-experts use case obsolete.

--- a/docs/adr/0008-debate-rounds-anonymization-injection.md
+++ b/docs/adr/0008-debate-rounds-anonymization-injection.md
@@ -1,0 +1,81 @@
+# ADR-0008: Debate rounds with blind R1, stable anonymization, per-session nonce
+
+**Status:** Accepted (Round 4 sign-off, 2026-04-21). Extends ADR-0005; supersedes ADR-0006.
+
+## Context
+
+ADR-0006 deferred debate rounds to v2. Multi-round debate between experts demands three design choices, each with a meaningful alternative:
+
+1. **Round 1 shape** — can experts see peers in R1, or is R1 blind?
+2. **Identity across rounds** — do labels stay stable, rotate, or use named roles?
+3. **Injection boundary** — how do we prevent expert output from breaking out of its wrapper and injecting into the judge's task block or a later round's aggregate?
+
+Expert output is LLM-generated text. Plain ASCII delimiters (v1 style: `=== EXPERT: A ===`) are forgeable — an expert can emit those literal strings as part of its answer, intentionally or by accident, and corrupt downstream prompt construction.
+
+Alternatives:
+
+- **Peer-aware round 1** (sequential) — rejected on wall-time grounds: N=3..5 experts running sequentially dominates latency.
+- **Per-round label rotation** — harder to fingerprint but confuses debate semantics ("Expert B said X in R1, Y in R2 — why?") and debug logs.
+- **Named roles** ("Engineer", "Ethicist") — leaks role information into expert prompts, breaking the "all experts get the same prompt" invariant.
+- **Plain ASCII fences (v1-style)** — no forgery defense.
+- **Per-section SHA-256 fences** — over-engineered under trusted-operator threat model; noise in logs. Deferred to v3.
+- **Blind R1 + stable labels + per-session nonce** — chosen.
+
+## Decision
+
+**R1 is blind; R2+ is peer-aware.** All experts run round 1 in parallel with no visibility into peer outputs. From round 2 onward, each expert receives an aggregate of the previous round's peer outputs (excluding itself), ordered alphabetically by anonymized label to keep prompts identical across reruns.
+
+**Labels are stable per session.** "Expert A", "Expert B" refer to the same real expert throughout one run. The label→real-name map is derived deterministically by hashing `session_id` (SHA-256, first 8 bytes → `math/rand/v2` PCG), stored only in `verdict.json.anonymization`, and revealed to humans post-hoc.
+
+**Label alphabet:** single letters `A`, `B`, `C`, …, `Z`. Scales up to N=26 at worst; v2 defaults N=3 so single letters suffice. For N>26, the obvious extension `A1, A2, …` is available — Round 5 simplification removed vote-path candidate IDs so there is no longer a collision concern. Deferred to v3 when multi-expert configurations beyond 26 become relevant.
+
+**Per-session 16-hex nonce** (8 bytes of entropy from `crypto/rand`) tags every prompt fence in the session:
+
+```
+=== EXPERT: A [nonce-7c3f9a2b1d4e5f60] ===
+...
+=== END EXPERT: A [nonce-7c3f9a2b1d4e5f60] ===
+```
+
+All LLM-sourced text going into a downstream prompt is fence-wrapped, and the wrapped content is scanned for the session nonce as a substring AND for ANY line-anchored delimiter pattern `(?m)^=== .* ===$` (including open fences like `=== EXPERT: A [nonce-…] ===`, close fences like `=== END EXPERT: A [nonce-…] ===`, and global section fences like `=== CANDIDATES ===` / `=== END CANDIDATES ===`). A match on either check rejects the output (forgery detection). The broad delimiter regex is deliberate — without the session nonce an attacker cannot forge an open fence, but they could still emit a closing or global delimiter to confuse downstream prompt parsing. Rejecting all delimiter-shaped lines from LLM-sourced content closes that gap.
+
+**Nonce scope (Round 5 v2):** fence ALL LLM-derived text going into a downstream prompt:
+- Expert R1 outputs when building R2 peer aggregates.
+- Expert R2 outputs when building the global aggregate that feeds the vote ballot prompt.
+
+Operator's question text is NOT fenced (trusted-operator threat model) but IS sanity-scanned at load time with the same delimiter regex; a match exits with `status: injection_suspected_in_question`, exit 1.
+
+**Historical (Round 4, superseded):** earlier drafts of this ADR also fenced judge prompts, tournament-judge prompts, factual-unanimity-judge prompts, and classifier rationale. Those components were removed in Round 5 (see superseded ADR-0007 and ADR-0009); the nonce scope above reflects the current v2 design with only debate rounds + vote remaining.
+
+**Future / v3 — per-round position shuffle seed derivation (not used in v2):** v2 peer aggregates are ordered alphabetically by anonymized label for determinism; there is no shuffle in v2. If a future v3 experiment reintroduces position shuffling, use `sha256(session_id || round_num || self_label)` → first 8 bytes → `rand.NewPCG(seedHi, seedLo)` so shuffles remain reproducible for debugging. The seed formula is documented here so the v3 implementer doesn't reinvent it.
+
+## Consequences
+
+- **(+)** Debate rounds work without self-preference or recency-bias leakage across rounds — labels are stable; peer-aggregate ordering is deterministic.
+- **(+)** Same session reruns produce identical prompts given identical expert outputs — reproducibility for debugging.
+- **(+)** Forgery via plain-ASCII fences is stopped by nonce verification — an attacker needs the session's nonce to forge a convincing fence.
+- **(+)** Operator's question stays un-fenced (no user-visible noise) while still being load-time-sanity-scanned.
+- **(−)** Writing-style leak — an expert's signature phrasing may reveal its real identity across rounds (e.g., specific Claude phrasings). Accepted as known limitation (R-v2-06); per-expert style anonymization deferred.
+- **(−)** Blind R1 means experts cannot cross-pollinate in round 1 — diversity of initial drafts is the gain, richness of R1 is the cost. Acceptable given R2+ is peer-aware.
+- **(−)** Under a trusted-operator threat model, the 16-hex nonce is sufficient; in an untrusted-executor future (v3 with multi-vendor CLIs) per-section SHA-256 hashes may be needed. Documented upgrade path.
+
+## Compliance
+
+- **F8** (fitness function): `verdict.json.anonymization` resolves to the same real name for every occurrence of a label across all rounds — `jq -e '.anonymization as $map | [.rounds[].experts[] | {label, real_name}] | unique | all(. as $e | $map[$e.label] == $e.real_name)'`.
+- **F5** (fitness): SIGINT mid-run produces partial `verdict.json` with the anonymization map intact.
+- **F9 (proposed)**: forge an expert output containing a fake fence without the session nonce → orchestrator rejects the output and marks the expert as failed for that round.
+
+## Research
+
+- Du et al 2024 — blind-first + peer-aware-downstream pattern; empirical gains on reasoning benchmarks come from the R2+ peer-aware phase.
+- ReConcile — stable-identity viability at N=3 for reasoning tasks.
+- Dalkey 1969 (Delphi) — classical authority on anonymized expert panels.
+- Panickssery et al 2024 — self-preference bias, accepted as known limitation.
+
+## Supersedes
+
+- [ADR-0006 — judge synthesizes only, no debate rounds at MVP](0006-synthesis-only-judge.md). The single-pass v1 design is replaced in v2 by a debate+vote flow under the single `defaults/default.yaml` profile. The anticipated `--rounds N` flag in ADR-0006 was reshaped into a profile-level `rounds:` field (default K=2; K∈{1,2} allowed), rather than a CLI flag.
+
+## Extends
+
+- ADR-0005 — v2 raises the N default to 3 in the single profile, adds validation `len(experts) >= 2`. The "single CLI, multiple personas" thesis stays in force; v2 just tightens the minimum and adds a vote stage after the final round.

--- a/docs/adr/0009-tournament-self-defense.md
+++ b/docs/adr/0009-tournament-self-defense.md
@@ -1,0 +1,61 @@
+# ADR-0009: Pairwise tournament with self-defense as conditional tie-break
+
+**Status:** **Superseded** by v2 simplification (Round 5, 2026-04-21). v2 reframed to a unified debate+vote flow where voting is the sole aggregation mechanism; the tournament + self-defense layer was removed. On a three-way tie at N=3, v2 surfaces all tied outputs to the operator instead of triggering a tournament (per design doc D16, YAGNI). See `docs/design/v2.md` Round 5 status banner for rationale.
+
+This ADR is retained for historical record — the Round 4 reasoning (Irving et al 2018 two-agent debate framework, Panickssery 2024 self-preference bias caveat) remains valid research should v3 reintroduce a close-vote argumentation layer.
+
+## Context
+
+The vote flow (see ADR-0007) aggregates expert ballots into a tally and picks a winner. Close votes — where the winner gets ≤60% of total votes — are the cases where a judge polishing the tally winner is most likely to be wrong: two candidates are close in merit, and a 60/40 split may not reflect the better answer. (Each expert casts one unweighted vote; weighted voting was dropped on YAGNI grounds in Round 4.)
+
+For these cases a second argumentation layer is helpful: let each top candidate's advocate make a case for its answer, then a tournament judge picks a winner based on the argument quality.
+
+Alternatives:
+
+- **Always polish the tally winner** (no tournament) — drops argumentation on close calls; the 60/40 edge case was exactly the reason the vote flow was introduced.
+- **Cross-defense** (A defends B's candidate, B defends A's) — no research supports cross-defense; cognitively strange for the defender.
+- **Neutral defenders** (spawn fresh experts who did not participate) — wastes a subprocess slot; for N=2 it burns one of the two existing experts anyway.
+- **Self-defense** (original author defends its own candidate) — used in Irving et al 2018's two-agent + judge framework. Honest about the argumentation cost: the original author knows its reasoning best. Self-preference bias (Panickssery et al 2024) accepted and documented.
+
+## Decision
+
+When the vote winner gets **≤60%** of total votes, a tournament runs between the top-2 candidates:
+
+1. Each candidate is defended by the expert that originally produced it.
+2. A tournament judge reads both defenses and picks the winner.
+3. The final judge polishes the tournament winner into the user-facing answer.
+
+**Tournament judge prompt** refers to **candidates**, not experts: "Defender of Candidate A1" / "Defender of Candidate A2". No session-stable labels (no "Expert A"), no disclosure that self-defense is happening. Preserves the anonymization boundary from ADR-0008.
+
+**Edge case — both top-2 candidates came from the same expert:** the tournament is **skipped** and the judge polishes the tally winner directly (single-source → no meaningful pairwise argumentation).
+
+**Tournament judge timeout:** folds into `judge.timeout` unless `vote.yaml` sets `voting.tournament_judge.timeout` as an override (the nested form matches the rest of the v2 vote-profile schema). The defender subprocess timeouts come from the defender's own `expert.timeout` field (defenders ARE the source experts) — no separate `defender_timeout` config knob (dropped Round 4).
+
+**Tournament failure** (`tournament_judge_failed`): exit 0 with a lexicographic fallback winner (v1-style best-effort; consistent with ADR-0005's lenient quorum posture — partial answer beats aborted run).
+
+**Threshold:** default `voting.tournament_trigger_threshold: 0.60` in `vote.yaml`. Operators can raise or lower it per-profile.
+
+## Consequences
+
+- **(+)** Close votes (≤60%) get a second argumentation pass — not just a mechanical polish of the tally.
+- **(+)** Single-source edge case handled cleanly: tournament skipped, no wasted subprocess.
+- **(+)** Tournament judge prompt is candidate-oriented, not expert-oriented — anonymization (ADR-0008) and mode separation preserved.
+- **(+)** Failure degrades gracefully (lexicographic fallback, exit 0) — debate never deadlocks on tournament failure.
+- **(−)** Self-preference bias (Panickssery et al 2024) means the defender may argue its own position slightly more persuasively than a neutral evaluator would. Acknowledged; deferred to v3 via optional `--tournament-mode cross|neutral` flag.
+- **(−)** Close votes add one additional pairwise-judge LLM call — latency + token cost on the cases that hit the threshold. Accepted as the price of argumentation depth where it matters.
+- **(−)** The 60% threshold is a judgment call, not a researched optimum. Mitigated by per-profile override.
+
+## Compliance
+
+- **F11** (fitness function): tournament-trigger arithmetic uses threshold inequality, not float equality. Mock tally `{"A1":4,"A2":2,"A3":2}` → winner_share = 0.5 ≤ 0.60 → tournament triggers; `jq -e '.tournament != null and (.voting.winner_share <= 0.60)'` passes.
+- Inverse fitness: winner_share > 0.60 → no tournament → `jq -e '.tournament == null and (.voting.winner_share > 0.60)'`.
+
+## Research
+
+- Irving et al 2018 — original two-agent + judge tournament framework.
+- Panickssery et al 2024 — self-preference bias documented; accepted at v2.
+
+## Relation to other ADRs
+
+- Depends on [ADR-0007 (classifier selects per-type profile)](0007-classifier-selects-per-type-profile.md): tournament is a step inside the `vote` flow only.
+- Depends on [ADR-0008 (anonymization + nonce)](0008-debate-rounds-anonymization-injection.md): tournament judge prompts are nonce-fenced; candidate labels (A1/A2) reuse the anonymization scheme.

--- a/docs/architect-review.md
+++ b/docs/architect-review.md
@@ -106,16 +106,19 @@ The session folder **is** the data model:
 
 ## Part C — ADRs
 
-Six ADRs capture the key decisions (see `docs/adr/`):
+Nine ADRs capture the key decisions (see `docs/adr/`):
 
 - **0001** — Go orchestrator; no LLM in the decision loop.
 - **0002** — Subprocess IPC via stdin/stdout/exit codes (not argv — `ARG_MAX` limit).
 - **0003** — File-based session artifacts (folder-as-database) with atomic `verdict.json`.
-- **0004** — Flat single-file config for MVP; defer the `profiles/experts/judges/` split.
-- **0005** — Single model/CLI at MVP (Claude Code); default profile ships N ≥ 2 expert personas.
-- **0006** — Judge synthesizes only; no debate rounds at MVP.
+- **0004** — Flat single-file config for MVP; defer the `profiles/experts/judges/` split. *Retained in v2 (Round 5 simplification reverted the multi-profile split from Round 4).*
+- **0005** — Single model/CLI at MVP (Claude Code); default profile ships N ≥ 2 expert personas. *Extended by ADR-0008 in v2 (N=3 default; `len(experts) >= 2` required).*
+- **0006** — Judge synthesizes only; no debate rounds at MVP. *Superseded by ADR-0008 in v2 (debate rounds added; judge itself removed per design doc D15).*
+- **0007** — LLM classifier selects per-type profile (synthesis/vote/factual). *Added in v2 Round 4; **superseded** by v2 Round 5 simplification (single flow, no classifier). Retained for historical record.*
+- **0008** — Debate rounds with blind R1, stable anonymization, per-session nonce injection boundary. *Added in v2.*
+- **0009** — Pairwise tournament with self-defense as conditional tie-break on close votes (≤60%). *Added in v2 Round 4; **superseded** by v2 Round 5 simplification (tournament removed; vote uses simple plurality). Retained for historical record.*
 
-Each ADR records alternatives considered and the consequence trade-offs.
+Each ADR records alternatives considered and the consequence trade-offs. The v1 sections of this review (Parts A/B/D/E) describe the MVP scope; v2 additions (debate rounds + anonymization + voting + resume) layer on top of the same bounded contexts, with `pkg/debate/` as the only new package — see `docs/design/v2.md` and `docs/plans/2026-04-22-v2-debate-engine.md`.
 
 ---
 
@@ -162,3 +165,97 @@ The three remaining architectural tasks before implementation starts:
 3. **Verify upstream CLI flags against the current release** and fold the result back into the spec (P1).
 
 After these, the remaining work is tactical — how to implement — not strategic.
+
+---
+
+## Part G — v2 additions (debate engine)
+
+**Scope:** this section adds the systems-analysis lens for v2 changes introduced by `docs/design/v2.md` and `docs/plans/2026-04-22-v2-debate-engine.md`. v1 sections A–F remain authoritative for the MVP scope. v2 layers debate rounds + anonymization + voting + resume on top of the same bounded contexts; Part G captures what the addition changes.
+
+**Note:** Round 5 simplification (2026-04-21) reverted Round 4's classifier + three-flow architecture. What Part G described previously (classifier, tournament, factual-unanimity judge) has been removed from v2. ADRs 0007 and 0009 are superseded but retained for history.
+
+### G.1 — New bounded contexts
+
+One new package; total grows from 7 to 8 bounded contexts. Process-oriented (what the system *does*), not entity-oriented — no Entity-Service smell.
+
+1. **`pkg/debate`** — cohesive debate engine: round lifecycle (R1 fan-out + R2 peer-aware fan-out), `aggregate.md` assembly, anonymization (label assignment via seeded shuffle), voting (ballot fan-out + tally + winner-or-tied selection). One package; internal file split (`rounds.go`, `vote.go`, `anonymize.go`) as size demands.
+
+Existing v1 contexts keep their v1 shape; `pkg/orchestrator` gains the multi-round pipeline + vote stage, `pkg/config` gains `rounds` and `voting` fields, `pkg/session` gains the `rounds/N/…` + `voting/` layout, `pkg/prompt` gains three new assemblers (R1 expert, R2 peer-aware expert, ballot) + two injection helpers (`Wrap`, `CheckForgery`). `pkg/runner` and `pkg/executor/claudecode` are unchanged.
+
+### G.2 — `pkg/debate` cohesion check
+
+`pkg/debate` holds four concerns (rounds, aggregate, anonymization, voting) — well inside the cohesion threshold for a single Go package. All concerns share the same session-scoped state (session ID, anonymization map, session nonce, per-round outputs, seed formulas); splitting would require threading a `SessionState` struct across multiple packages for no cohesion win.
+
+**Guard rail:** if `pkg/debate` exceeds ~1000 LOC or its internal files stop sharing state cleanly, revisit the split with a dedicated `pkg/debate/state.go` + thin subpackages. File-level split inside the package is the first line of defense.
+
+### G.3 — Quality-attribute drift
+
+v1's explicit QAs (Performance <60s, Testability, Simplicity) do not survive v2 unchanged. The shift:
+
+| Attribute | v1 | v2 | Δ |
+|---|---|---|---|
+| **Performance** | < 60s simple question | ~3-5 minutes (blind R1 + peer-aware R2 + vote ballot fan-out) | **Regressed deliberately** — debate is 3–5× more expensive than single-pass (design §1.4). |
+| **Testability** | Exit-code + verdict schema | Same + anonymization invariant + vote outcome invariant | **Extended.** |
+| **Simplicity** | One binary, one build, one profile | Same — single `default.yaml`, no type dispatch | **Preserved** after Round 5 simplification. |
+| **Accuracy** | Implicit (single pass) | **New explicit QA** — debate's raison d'être (Du et al +7–15% on reasoning). |
+| **Determinism / reproducibility** | Folder-as-database | **New explicit QA** — same session re-plays produce identical prompts given identical expert outputs (fitness F8); anonymization is deterministic from session_id. |
+| **Fairness / no single-model bias** | Implicit (single judge) | **New explicit QA** — voting distributes decision across all N experts; no single judge dominates (design D15). |
+| **Resumability** | Absent | **New explicit QA** — `council resume` lets a session continue from the last completed stage after SIGINT / network blip / rate-limit wall (design D14). |
+
+**Not priorities in v2 either** (carry-forward from v1): scalability, availability, security (single-user + trusted-operator threat model).
+
+### G.4 — Coupling delta
+
+Added couplings (all acceptable):
+
+| Pair | Coupling types | Assessment |
+|---|---|---|
+| `pkg/debate` ↔ `pkg/prompt` | Semantic (label alphabet, nonce format, fence regex) | **Load-bearing contract.** Codified in ADR-0008. |
+| `pkg/debate` ↔ `pkg/session` | Static (folder paths `rounds/N/experts/<label>/`, `voting/`) | Pre-nested from v1 (ADR-0003 extension). Zero migration cost. |
+| `verdict.json` v2 consumers ↔ schema | Static + Semantic, versioned (`"version": 2`) | v1 → v2 is a schema extension (flat `experts[]` + `judge` → `rounds[].experts[]`, added `anonymization`, `voting`; removed `judge` per D15). Migration note in README. |
+
+Existing v1 couplings unchanged. Note that Round 4's `pkg/orchestrator ↔ pkg/classifier` coupling is removed along with the classifier.
+
+### G.5 — v2 risk register (delta)
+
+P1 / P2 / P3 scale continues from v1. Risks flagged by v2 design review:
+
+| P | Risk | Mitigation |
+|---|---|---|
+| P1 | Nonce-based injection is sufficient under trusted-operator threat model but **not under adversarial/multi-vendor** (v3 will add executors outside our control) | Upgrade path documented in ADR-0008 — per-section SHA-256 hashes when multi-vendor CLIs arrive |
+| P2 | Writing-style leak across rounds reveals expert identity despite stable-label anonymization; can bias voting | Accepted as known limitation R-v2-06; style-anonymization deferred to v3 |
+| P2 | Raw expert R2 text may be rougher than judge-polished prose | Accepted trade-off of D15 (no judge); if problematic in practice, v3 may add a narrow polish step with proven-narrow contract |
+| P2 | 1-1-1 three-way tie at N=3 surfaces all outputs (no tiebreak) | D16 YAGNI: operator chooses from three tied answers; add tiebreak logic only when operational data shows it's needed |
+| P2 | verdict.json v1 consumers break on v2 schema | Migration note + version bump `1 → 2`; downstream must pin version |
+| P3 | `pkg/debate` size creep past ~1000 LOC → cohesion degrades | G.2 guard rail; file-level split first, package split if unavoidable |
+
+P3 "N=1 under-exercises fan-out bugs" from v1 is **retired** — v2 defaults push N to 3 and validator requires `len(experts) >= 2`.
+
+Retired from Round 4 (no longer applicable after simplification): classifier miscalibration risk, tournament self-preference bias risk, classifier confidence-threshold risk — all specific to removed features.
+
+### G.6 — Fitness functions (v2)
+
+v1 had 7 fitness functions; v2 retains those plus adds three:
+
+- **F8** — anonymization stability: every label occurrence resolves to the same real name.
+- **F9** — injection forgery rejection: forged expert output with fake fence (no nonce) is rejected.
+- **F12** — vote outcome: `verdict.json.voting.winner` or `voting.tied_candidates` is populated (exactly one).
+
+F2 updated to check v2 schema (`rounds[]`, `voting`, `anonymization`). F4 path updated (`rounds[0].experts[].retries`).
+
+Retired: F10 (classifier output schema) and F11 (tournament trigger arithmetic) — both were specific to Round 4 removed features.
+
+F9 is retained as unit-test coverage in v2, not as a gating fitness function enforced by CI — the per-session nonce is small and unit-tested at the boundary.
+
+### G.7 — Verdict
+
+v2 preserves v1's clean architecture profile and adds one new bounded context (`pkg/debate`) without introducing Entity-Service or Technical-Steps anti-patterns. The remaining load-bearing strategic decision is ADR-0008 (debate rounds + anonymization + nonce). ADRs 0007 and 0009 exist as historical record of the Round 4 classifier/tournament decisions that Round 5 simplified away.
+
+Architectural tasks before v2 implementation starts:
+
+1. **Round 5 simplification signed off** (2026-04-22): Single flow, no classifier, no judge, no tournament, no factual path. Voting is the sole aggregation mechanism; three-way ties surface all outputs (YAGNI per D16). Design is accepted.
+2. **Validate `claude -p --model sonnet`** still works as v2's expert executor (preserved from v1; no new model validation needed for the simplified design).
+3. **Verdict.json v2 migration note** — README documents that v2 bumps `version` to 2 and adds `rounds[]`, `anonymization`, `voting` fields; removes `judge`. Downstream tools must pin version.
+4. **Size-monitor `pkg/debate`** during implementation; if it approaches the 1000-LOC threshold, activate the G.2 guard rail.
+
+v2 is a meaningful architectural addition but not a rewrite — the v1 pipeline + folder-as-database + `Executor` interface + single-CLI constraint all carry forward intact. Round 5 simplification further preserves v1's simplicity by reverting to a single profile and a single flow.

--- a/docs/design/v2.md
+++ b/docs/design/v2.md
@@ -1,0 +1,1024 @@
+# council v2 — Debate Engine Design
+
+> **This is the source-of-truth design document.** The ralphex implementation plan at
+> `docs/plans/2026-04-22-v2-debate-engine.md`, the ADRs at `docs/adr/0007-0009`, and the
+> runtime artifacts (`defaults/*`) are all derivatives rendered from the
+> decisions below. Edit this file first; derivatives follow.
+
+## 1. Problem & Goal
+
+### 1.1 Where v1 left off
+
+v1 is a single-pass system: the user asks a question, N experts answer in
+parallel, one judge synthesizes one final answer. ADR-0006 explicitly
+defers round-based debate to v2 behind a future `--rounds N` flag:
+
+> MVP runs a single fan-out pass: each expert answers the original question
+> once, the judge synthesizes. No back-and-forth.
+
+### 1.2 What v2 adds
+
+A small debate engine: experts run one blind round, then one peer-aware
+round where they see each other's reasoning (anonymized), then vote on
+whose final answer is best. The winner's answer is returned verbatim.
+No judge, no synthesis, no polish.
+
+### 1.3 Why now
+
+Empirical research on multi-agent LLM systems (see §6 Research Map) shows
+measurable accuracy gains from round-based debate on reasoning tasks:
++7–15% over single-pass on reasoning benchmarks (Du et al 2024, Chen et al
+2024). v1's single-pass design leaves those gains on the table and —
+more practically — doesn't match the mental model people have when they
+reach for "a council" ("I want N expert opinions that actually argue, not
+N parallel monologues").
+
+### 1.4 What v2 is NOT
+
+- Not a performance tool — debate is 3–5× more expensive than v1.
+- Not a multi-vendor framework — v2 still runs on Claude Code only;
+  architecture is ready for Codex/Gemini in v3.
+- Not a benchmark runner — no built-in evaluation harness.
+- Not a self-repair system — v2 does not autonomously recover or revise
+  failed runs, but operators can explicitly continue interrupted work
+  via `council resume` (D14) rather than always rerunning from scratch.
+- **Not a structured-output answer tool** — the user-facing result is
+  human-readable prose (the winner's R2 text, or all three outputs on
+  a 1-1-1 tie). v2 still emits structured audit artifacts in the
+  session folder (`verdict.json` with `voting` fields, `voting/tally.json`)
+  for inspection and debugging, but no downstream-facing schema
+  contracts are promised. Richer answer-level schemas (structured
+  factual dispute outputs, etc.) remain v3 candidates.
+
+## 2. The Engine at a Glance
+
+### 2.1 One-sentence summary
+
+Call `council "<question>"`: N experts run K rounds of anonymized debate
+(blind R1, peer-aware R2), then vote on each other's final answers. The
+winner's R2 text is returned verbatim. On a three-way tie, all tied
+answers are surfaced; operator decides.
+
+### 2.2 The single flow
+
+```
+question
+  │
+  ▼
+Round 1 (blind):         Round 2 (peer-aware):         Vote:             Output:
+  Expert A ─┐              Expert A ←── sees B, C       each expert      winner's R2
+  Expert B ─┼── parallel   Expert B ←── sees A, C  ──▶  votes for    ──▶ text verbatim
+  Expert C ─┘              Expert C ←── sees A, B       any label         (or all tied
+                                                        (incl. own)       on 1-1-1)
+```
+
+No classifier, no type branching, no judge. One flow for every question.
+Peer aggregate for each expert is ordered alphabetically by anonymized
+label (Expert B, C, D appear in A's aggregate in that order) — ensures
+identical prompts across reruns.
+
+### 2.3 What ties it all together
+
+Folder-as-database (v1 pattern, kept). Every run writes a self-contained
+`.council/sessions/<timestamp>-<adj>-<adj>-<noun>/` folder (petname suffix, inherited from v1) with per-round,
+per-expert artifacts, a `verdict.json` index, and voting tallies. Every run is fully
+reproducible from this folder alone. No database, no hidden state.
+
+**Quorum (v1 field, `quorum: 1` default) applies per-round in v2:** after
+each round's subprocess fan-out, surviving_count >= quorum must hold or
+the run exits `quorum_failed_round_N`. See D3 for carry-forward rules.
+
+## 3. End-to-end walkthrough
+
+A step-by-step trace of one complete run. Complements §2's abstract
+view with a concrete example so readers can see the pipeline in action
+before diving into §4's decision records.
+
+**Example:** `council "Should we use Raft or Paxos for our cluster?"`
+with N=3 experts, K=2 rounds.
+
+### 3.1 Session setup (pre-debate)
+
+Orchestrator does all of this before any expert runs:
+
+1. **Session ID** — generates petname `2026-04-22T10-14-30Z-fizzy-jingling-quokka`.
+2. **Session nonce** — generates 16-hex random string from `crypto/rand`, e.g. `7c3f9a2b1d4e5f60`. Stored in `profile.snapshot.yaml`.
+
+   > **Why not a petname like the session_id?** The session_id is a **user-facing** identifier — it names the session folder, appears in stdout, gets referenced in `council resume --session <id>`. Human-friendliness wins there.
+   >
+   > The nonce has a different job: it is an **injection-defense secret**. If an expert knew or could guess the nonce, it could forge a convincing `=== EXPERT: X [nonce-...] ===` fence inside its own output and break out of the prompt structure when that output is later embedded into a downstream prompt (peer aggregate, ballot). So the nonce MUST be unguessable.
+   >
+   > A petname has ~10–15 bits of entropy (bounded wordlist). 16-hex = 64 bits. That's the difference between "brute-forceable in milliseconds" and "impractical to guess." Hex is ugly but correct for this job.
+3. **Anonymization** — deterministically shuffles real expert names to labels:
+   - `seed = sha256("2026-04-22T10-14-30Z-fizzy-jingling-quokka")`
+   - PCG random shuffle: `{A: expert_2, B: expert_1, C: expert_3}`
+   - Mapping stored in `verdict.json.anonymization` only (revealed post-hoc).
+4. **Question injection scan** — checks the operator's question string for any line matching the delimiter pattern `^=== .* ===$` (same regex we reject in expert output). Clean → continue. Dirty → exit 1 `injection_suspected_in_question`.
+
+   > **What is it / why do we need it?** Our debate+vote pipeline embeds content into prompts using fenced delimiters like `=== EXPERT: A [nonce-...] ===`. LLM-sourced output is fence-wrapped with the session nonce AND forgery-scanned. But the operator's question is NOT fenced — under our trusted-operator threat model, we embed it as-is into prompts.
+   >
+   > The problem: if the operator accidentally pastes content containing `=== ...===` lines (for example copy-pasting a prior debate transcript as the question, or using markdown-heavy formatting that collides with our delimiter), that content becomes structural-looking text inside the prompt we send to experts. It could confuse downstream prompt parsing or leak structural signals into expert outputs.
+   >
+   > The fix is a simple load-time sanity check: if the question itself contains delimiter-shaped lines, stop before spawning any expert and tell the operator. Failing loudly at boundary-time beats producing a confused run.
+
+### 3.2 Round 1 vs Round 2 — what's the difference?
+
+| | Round 1 (R1) | Round 2 (R2) |
+|---|---|---|
+| **What expert sees** | Only the operator's question | Operator's question **+** anonymized outputs from other experts' R1 |
+| **Mental task** | "What's my independent answer to this question?" | "Now that I've seen what B and C said, do I refine, challenge, or maintain my position?" |
+| **Runs in parallel?** | Yes — all N experts run simultaneously | Yes — all N experts run simultaneously, but each sees R1 peers |
+| **Can see own prior output?** | No (first round, no prior) | No — each expert's R2 prompt excludes its own R1 output (so experts don't echo themselves) |
+| **Failure handling** | Failed expert is **dropped** from session (no prior round to carry) | Failed expert uses its R1 output as R2 (**carry-forward** — preserves contribution) |
+
+**Why both rounds?**
+
+- **R1 alone** would be v1: single-pass, no debate. Experts can't disagree with each other because they never see each other.
+- **R2 alone is impossible** — peer-aware means you need peer content to show, but in the first parallel round nobody has finished yet. There's nothing to be peer-aware of.
+- **R1 → R2** solves both: R1 seeds diversity of independent drafts (no groupthink from shared context), R2 lets that diversity productively argue (experts update their position after seeing others).
+
+The research (Du et al 2024) shows the accuracy gains from debate come from the R2+ peer-aware phase, not from R1. R1 exists to seed the diversity that R2 can then refine.
+
+### 3.3 Round 1 (blind, parallel)
+
+All 3 experts run simultaneously. Each gets: role prompt + question. No peer context.
+
+```
+                ┌─ Expert labeled A (real = expert_2) ──→ output.md: "Use Raft. Simpler..."
+                │
+question ──────┼─ Expert labeled B (real = expert_1) ──→ output.md: "Use Raft. Ecosystem..."
+                │
+                └─ Expert labeled C (real = expert_3) ──→ output.md: "Use Paxos. Byzantine..."
+```
+
+**Each output saved** to `rounds/1/experts/<A|B|C>/output.md` (atomic write: tmp + fsync + rename) followed by a `.done` marker file.
+
+> **Why BOTH atomic `output.md` AND a separate `.done` marker?** The atomic write already guarantees `output.md` is never seen in a partial state (readers get the whole file or no file).
+>
+> The two serve different purposes:
+> - **Atomic `output.md`** = "this one file is fully written." One-file-level durability.
+> - **`.done` marker** = "the entire stage (subprocess run + output capture + forgery scan + any stderr capture) completed cleanly." Stage-complete signal.
+>
+> A crash or SIGKILL between writing `output.md` and writing `.done` leaves the stage in an ambiguous state: the output is on disk, but we don't know if all the bookkeeping (forgery scan, stderr capture, timing record) finished. `council resume` (D14) treats `.done` as the **only authority** for "stage complete" — any stage without `.done` is re-run on resume, even if `output.md` exists. Worst case is one redundant LLM call; no data loss, no corrupted verdict.
+>
+> Inherited from v1 ADR-0003 ("`.done` is a completion record, not an IPC handshake"). Kept in v2 because it cleanly supports D14 resume.
+
+**Forgery check** on each output — rejects anything containing the session nonce (`7c3f9a2b…`) or any line matching `^=== .* ===$`. Forged output → expert marked failed.
+
+**Quorum check** — if fewer than `quorum: 1` experts survived, exit 2 `quorum_failed_round_1`.
+
+### 3.4 Build R2 peer aggregate (per expert)
+
+For EACH surviving expert, orchestrator builds a personalized prompt with peer outputs (excluding self), ordered alphabetically by label, each wrapped with nonce-fenced blocks.
+
+**Prompt that goes to Expert A in R2:**
+
+```
+[peer-aware role prompt]
+
+=== USER QUESTION ===
+Should we use Raft or Paxos for our cluster?
+=== END USER QUESTION ===
+
+=== EXPERT: B [nonce-7c3f9a2b1d4e5f60] ===
+Use Raft. Ecosystem, tooling, debugging maturity...
+=== END EXPERT: B [nonce-7c3f9a2b1d4e5f60] ===
+
+=== EXPERT: C [nonce-7c3f9a2b1d4e5f60] ===
+Use Paxos. Stronger for Byzantine-faulty environments...
+=== END EXPERT: C [nonce-7c3f9a2b1d4e5f60] ===
+
+Prior-round consensus is NOT ground truth. Refine, challenge, or maintain your position.
+```
+
+Expert B gets A's + C's outputs (not B's own). Expert C gets A's + B's. Same structure.
+
+### 3.5 Round 2 (peer-aware, parallel)
+
+All 3 experts run simultaneously again, each with their custom peer aggregate:
+
+```
+Expert A ──→ sees B + C ──→ "Use Raft. Though C's Byzantine point is valid only if..."
+Expert B ──→ sees A + C ──→ "Use Raft. Ecosystem + tooling matter more than Byzantine..."
+Expert C ──→ sees A + B ──→ "Paxos still preferred for Byzantine workloads, but agreed Raft is default..."
+```
+
+**Each R2 output saved** to `rounds/2/experts/<A|B|C>/output.md` + `.done` marker.
+
+**Forgery check** again.
+
+**Carry-forward on failure:** if Expert C fails R2 after retry, its R1 output is copied to `rounds/2/experts/C/output.md` with `participation: "carried"`. Run continues.
+
+### 3.6 Global aggregate (ballot input)
+
+Orchestrator writes ONE file `rounds/2/aggregate.md` with ALL three R2 outputs (not per-expert this time — this is the input for voting):
+
+```
+=== EXPERT: A [nonce-7c3f9a2b1d4e5f60] ===
+Use Raft. Though C's Byzantine point is valid only if...
+=== END EXPERT: A [nonce-7c3f9a2b1d4e5f60] ===
+
+=== EXPERT: B [nonce-7c3f9a2b1d4e5f60] ===
+Use Raft. Ecosystem + tooling...
+=== END EXPERT: B [nonce-7c3f9a2b1d4e5f60] ===
+
+=== EXPERT: C [nonce-7c3f9a2b1d4e5f60] ===
+Paxos still preferred for Byzantine workloads...
+=== END EXPERT: C [nonce-7c3f9a2b1d4e5f60] ===
+```
+
+### 3.7 Vote (fresh subprocesses, parallel)
+
+Each expert is spawned AGAIN (fresh session, no prior-round context). Each receives the ballot prompt:
+
+```
+=== USER QUESTION ===
+Should we use Raft or Paxos for our cluster?
+=== END USER QUESTION ===
+
+=== CANDIDATES ===
+[the global aggregate from §3.6 — all three R2 outputs fenced]
+=== END CANDIDATES ===
+
+Pick the label whose answer is best. Output ONLY the line: VOTE: <label>
+```
+
+Experts vote (they CAN vote for their own answer — anonymization via labels is the mitigation, not self-exclusion):
+
+```
+Ballot A.txt: "VOTE: B"
+Ballot B.txt: "VOTE: B"
+Ballot C.txt: "VOTE: B"
+```
+
+(In this example everyone votes B. In practice this is rare; 2-1-0 splits are typical.)
+
+### 3.8 Tally + output selection
+
+```json
+voting/tally.json:
+{
+  "votes": {"A": 0, "B": 3, "C": 0},
+  "winner": "B",
+  "tied_candidates": null,
+  "ballots": [
+    {"voter_label": "A", "voted_for": "B"},
+    {"voter_label": "B", "voted_for": "B"},
+    {"voter_label": "C", "voted_for": "B"}
+  ]
+}
+```
+
+**Tally rule (general form):** unique max wins. If multiple labels are tied at the max vote count (including the degenerate all-zero case from all-malformed ballots) → `tied_candidates = [those labels]`. See D8 for the formal spec.
+
+**Output selection:**
+- Unique winner (B) → copy `rounds/2/experts/B/output.md` to session root `output.md`. Exit 0.
+- If it had been a tie (e.g., 1-1-1 at N=3 or 1-1 at N=2 reduced cohort): copy each tied label's R2 output to `output-A.md` / `output-B.md` / etc. Exit 2 `no_consensus`.
+
+### 3.9 Verdict + finality
+
+1. Orchestrator atomically writes `verdict.json` (tmp + fsync + rename).
+2. **Then** writes root-level `.done` marker — this is the finality signal for `council resume` (see D14).
+
+### 3.10 What the operator sees on stdout
+
+```
+$ council "Should we use Raft or Paxos for our cluster?"
+[Raft is the answer — the content of output.md, verbatim]
+
+Session: 2026-04-22T10-14-30Z-fizzy-jingling-quokka
+Verdict: .council/sessions/.../verdict.json
+```
+
+The operator never sees labels A/B/C during the run — those are internal. They just see the winner's prose.
+
+### 3.11 Key properties
+
+| Property | How it's achieved |
+|---|---|
+| No single-model bias in aggregation | Decision distributed across all N experts via voting (D15) |
+| Anonymized across rounds | Stable per-session labels A/B/C so experts argue about content, not identity (D2, ADR-0008) |
+| Injection-safe | Nonce fencing + broad delimiter-line rejection on all LLM-sourced output (D11, ADR-0008) |
+| Deterministic replay | Same session_id → same label assignment; debugging is reproducible (D2) |
+| Tolerant of flaky infra | Carry-forward preserves a good expert whose CLI hiccupped in R2 (D3, quality-first tolerance) |
+| Resumable | After SIGINT mid-R2, `council resume` picks up where it stopped (D14) |
+
+### 3.12 Failure modes (short)
+
+- **R1 failure after retry** — expert dropped; `participation_by_round[0] = "failed"`. Quorum check decides: if below quorum, exit 2.
+- **R2 failure after retry** — carry-forward: R1 output copied to `rounds/2/experts/<label>/output.md`, `participation_by_round[1] = "carried"`.
+- **Nonce forgery in LLM output** — output rejected, expert marked failed for that round, normal failure path applies.
+- **Delimiter line in LLM output** (even without nonce) — same as forgery: rejected.
+- **Injection pattern in operator question** — exit 1 before any LLM call.
+- **Tie on vote** — all tied outputs surfaced, exit 2 `no_consensus`, operator picks from the tied files.
+- **SIGINT mid-run** — v1 handler writes `verdict.json` with `status: "interrupted"` + anonymization map; session is resumable via `council resume` (D14).
+
+## 4. Design Decisions
+
+Each decision records: **What**, **Why**, **Alternatives**,
+**Research**, **Risk if wrong**.
+
+D-decision numbering preserves the gaps from Round 5 (D4/D8-old/D9/D13
+removed — see ADR-0007 and ADR-0009 for superseded rationale). D8 is
+re-scoped from "voting as a type-specific sub-flow" to "universal vote
+as final step."
+
+### D1 — Round 1 is blind, rounds 2..K are peer-aware
+
+**What:** In round 1, each expert answers independently without seeing
+others. Starting round 2, each expert receives an anonymized aggregate
+of all other experts' round-(N-1) outputs, **ordered alphabetically by
+anonymized label** (Expert B, C, D in A's aggregate, in that order —
+ensures identical prompts across reruns with identical expert outputs).
+
+**Why:** Two reasons, one physical and one empirical.
+
+1. **Physical / operational:** round 1 must run in parallel to be
+   tolerable in wall time. A peer-aware round 1 is impossible during
+   parallel execution — no peer has finished yet, so there is no peer
+   content to show. The only way to have peers visible in round 1 is to
+   run experts sequentially, which on N=3..5 is prohibitively slow for
+   no gain. Blind round 1 is therefore the only adequate solution
+   that preserves parallelism.
+2. **Empirical:** even if sequential round 1 were cheap, blind round 1
+   preserves diversity of initial drafts before peer influence enters
+   the pool. Debate begins at round 2. The diversity seeded in round 1
+   is what makes later-round debate productive.
+
+**Alternatives considered:**
+- Peer-aware sequential round 1 — rejected on wall-time grounds.
+- Peer-aware parallel round 1 with empty peer context — a no-op
+  single-code-path rename that changes nothing. Rejected as cosmetic.
+
+**Research:** Du et al 2024 uses blind-first + peer-aware-downstream
+pattern; empirical gains on reasoning benchmarks come from the R2+
+peer-aware phase.
+
+**Risk if wrong:** Structurally unchangeable — running round 1
+sequentially to get peer visibility would dominate latency.
+
+### D2 — Stable anonymization per session
+
+**What:** "Expert A" maps to the same real expert throughout one run.
+The mapping is generated by hashing the `session_id` string, stored only in
+`verdict.json.anonymization`, and revealed to humans post-hoc.
+
+**Why:** Experts need a consistent referent to argue across rounds
+("Expert B said X in round 1, now says Y — why?"). Rotating labels
+would break cross-round reasoning. Anonymization during vote prevents
+experts from identifying their own answer by label (style leak still
+possible — documented as known limitation).
+
+**Alternatives considered:**
+- Per-round rotation — harder to fingerprint but confuses debate
+  semantics and debug logs.
+- Naming by role ("Engineer", "Ethicist") — leaks information into prompts.
+
+**Research:** ReConcile demonstrates stable-identity viability at N=3
+for reasoning tasks; Dalkey 1969 (Delphi) is the classical authority
+on anonymized expert panels.
+
+**Risk if wrong:** Writing-style leak — an expert's signature phrases
+reveal its real identity (e.g., specific Claude phrasings). Documented as
+known limitation R-v2-06. Acceptable at v2.
+
+### D3 — Partial failure: carry forward last-known-good
+
+**What:** If an expert fails in round N (even after retry), the
+orchestrator reuses its last successful output as if the expert
+"participated" in round N, and marks `participation: "carried"` in the
+verdict. The run continues.
+
+**Round 1 failure rule:**
+- If an expert fails round 1 after `max_retries`, the expert is DROPPED
+  from the session (no last-known-good exists to carry).
+- `participation_by_round[0] = "failed"` is recorded for that expert.
+- After R1, check `surviving_count >= quorum` — if below, exit with
+  v1-style `status: quorum_failed_round_1`, exit 2.
+- R2..RK run with the reduced cohort. The carry-forward rule applies
+  when an expert fails in R2+ (has round-1 output to carry).
+
+**Why:** The "guaranteed answer, no deadlocks" requirement rules out
+aborting on single-expert failures. Quality-first tolerance: a great
+model with flaky CLI/API shouldn't be dropped on a single failure. A
+best-effort run with a transparent audit trail beats an aborted run
+the operator has to rerun.
+
+**Alternatives considered:**
+- Abort with `status: round_failed` — safer for high-stakes cases but
+  hostile UX by default.
+- Hybrid with strict-participation flag — deferred to v3 (`--strict`
+  flag, explicit opt-in for critical runs).
+- Drop the expert (no carry-forward) — simpler but punishes a good
+  model whose API is flaky. Rejected per quality-first principle.
+
+**Research:** No direct research. Operational choice; similar degrade-
+gracefully pattern in ralphex.
+
+**Risk if wrong:** Stale outputs from "carried" experts mislead the
+vote. Mitigation: the operator sees `experts[].participation_by_round`
+in `verdict.json` and decides if the run is trustworthy.
+
+### D5 — Single default profile: `default.yaml`
+
+**What:** Ship one profile in `defaults/`:
+
+- `defaults/default.yaml` — N=3 experts × K=2 rounds (blind R1,
+  peer-aware R2), vote as final step, no judge.
+
+**Why:** One flow, one profile. No classifier, no type branching, no
+per-type YAML shapes. Operator customizes by editing `defaults/default.yaml`
+(or dropping overrides into `./.council/` to follow the v1 loader
+precedence — local > global > embedded) and uses `--profile <file>`
+for one-off non-interactive runs.
+
+**Alternatives considered:**
+- Multiple profiles (round 4 design: synthesis / vote / factual) —
+  superseded by Round 5 simplification. See ADR-0007 for history.
+- No profile file, hardcoded config — loses v1's operator-override
+  mechanism.
+
+**Research:** Du et al 2024 (3×2 as sweet spot for multi-agent
+debate). Chen et al 2024 (N=3 for reasoning tasks).
+
+**N/K defaults (M4):** N=3 enables tie-resistance (2-1-0 plurality
+works, true three-way ties are rare), quorum resilience if one expert
+fails, and matches Du et al default. K=2 (K=3 marginal accuracy gain
+triples per-round cost — operator can edit). N and K are operator-
+configurable; the single shipped default is N=3, K=2.
+
+**Risk if wrong:** One file, low maintenance burden. Migration for v1
+users: the profile shape is compatible with v1's `default.yaml` plus
+one new field (`rounds: 2`); v1 users can add `rounds: 2` to their
+existing `default.yaml` or let the embedded default take over.
+
+### D6 — Profile schema
+
+**What:** Single profile shape at `defaults/default.yaml`:
+
+```yaml
+version: 2
+experts:
+  - name: expert_1
+    prompt_file: prompts/independent.md
+    executor: claude-code
+    model: sonnet
+  - name: expert_2
+    prompt_file: prompts/independent.md
+    executor: claude-code
+    model: sonnet
+  - name: expert_3
+    prompt_file: prompts/independent.md
+    executor: claude-code
+    model: sonnet
+rounds: 2
+voting:
+  ballot_prompt_file: prompts/ballot.md
+quorum: 1
+max_retries: 1
+```
+
+**Implicit invariants (hardcoded in v2; no config knob):** anonymization
+is always stable per session (see D2); injection nonces are always
+enabled on every LLM-sourced fence (see D11). No classifier, no judge,
+no tournament, no self-defense — not configurable, they simply do not
+exist in v2.
+
+**N=1 validation (M5):** profile loader validates `len(experts) >= 2`
+at load time (debate requires ≥ 2 voices; voting requires ≥ 2 candidates).
+Exit 1 otherwise.
+
+**Why:** Clean single-purpose shape. Adding a new type in v3
+(e.g., ranking, factual with SOURCE verification) = adding a new
+profile file, no refactoring existing profile.
+
+**Alternatives considered:**
+- Per-type profiles (round 4 design with classifier) — superseded by
+  Round 5 simplification. See ADR-0007.
+- Flat keys at root — works too, nested `voting.ballot_prompt_file`
+  groups related config naturally.
+
+**Research:** Standard YAML convention.
+
+**Risk if wrong:** v3 introduces a distinct aggregation mode
+(ranking, rating, numerical) — fixable by adding a new profile file
+or adding type-dispatch back. Low cost.
+
+### D7 — No `--deadline` flag
+
+**What:** No wall-clock global cap. Total run time is bounded by per-round
+timeouts × K, plus vote timeout, from config.
+
+**Why:** Predictable from config. One less CLI flag.
+
+**Alternatives considered:**
+- Wall-clock `--deadline 5m` that force-aggregates remaining rounds —
+  useful for interactive users but adds a dynamic failure mode. Deferred
+  to v3 if demanded.
+
+**Research:** None — simplification choice.
+
+**Risk if wrong:** Long runs on complex questions. Operator can lower
+per-round timeouts in their profile.
+
+### D8 — Universal vote as final step
+
+**What:** After all K rounds complete, each surviving expert casts one
+unweighted vote. The ballot subprocess runs in a **fresh session** (no
+prior-round context) with the question + all R2 outputs wrapped as
+anonymized labels A/B/C (each fence carrying the session nonce). Each
+expert outputs exactly one line: `VOTE: <A|B|C>`.
+
+Experts may vote for any candidate including their own (no self-
+exclusion). Anonymization via labels prevents experts from explicitly
+identifying their own answer; writing-style leak is a known limitation
+(R-v2-06) but does not block the mechanism.
+
+**Tallying (general form):**
+
+Let `S` = the set of active candidate labels (surviving experts after the final round; `|S|` equals post-R2 cohort size). Let `votes: map[label → int]` be the tally of valid ballots over labels in `S`. Malformed ballots and ballots for labels not in `S` are discarded (do not count toward any candidate).
+
+- **Unique max → winner.** If exactly one label has the highest vote count, that label wins. Its R2 output is copied verbatim to `output.md` at session root. Exit 0.
+- **Multiple labels tied at max → no consensus.** Every label tied at the maximum vote count (including the degenerate case of all-tied-at-one or all-at-zero when every ballot was malformed) is a tied candidate. Each tied label's R2 output is copied to `output-<label>.md` at session root. `verdict.json.voting.tied_candidates` lists every tied label. Exit 2 `no_consensus`. See D16.
+
+**Example outcomes at N=3 full cohort:**
+- 3-0-0, 2-1-0 → unique max → winner.
+- 1-1-1 → three-way tie → all three surfaced.
+
+**Example outcomes at N=2 reduced cohort** (one expert dropped in R1, quorum still met):
+- 2-0 → unique max → winner.
+- 1-1 → two-way tie → both surfaced as `output-A.md` + `output-B.md`.
+
+**Degenerate edge case (all ballots malformed):** `votes` is all zero. Every active label is "tied at max (zero)" → every active output is surfaced, exit 2 `no_consensus`. Honest about the failure mode.
+
+No tournament, no self-defense, no close-vote argumentation layer, no
+threshold-triggered second pass. Vote is a single step with a single
+aggregation rule.
+
+**Why:** Voting distributes the final-answer decision across all N
+experts rather than concentrating it in a single judge (see D15).
+Plurality is the simplest aggregation rule compatible with N=3;
+adding ranked/Borda/Schulze is v3 territory.
+
+**Alternatives considered:**
+- Tournament + self-defense on close votes (superseded; see ADR-0009
+  for historical rationale). Round 5 reverted tournament.
+- Self-exclusion (expert cannot vote for own answer) — reduces
+  Panickssery self-preference bias but increases tie rate at N=3.
+  Rejected for mechanism simplicity; anonymization via labels is
+  the mitigation.
+- Confidence-weighted votes — Xiong 2024 says LLM confidence is
+  poorly calibrated. Deferred to v3.
+- Judge picks from R2 outputs instead of voting — see D15 for why
+  rejected.
+
+**Research:**
+- Du et al 2024 — multiagent debate uses **majority voting as the
+  aggregation mechanism** in multiple reported variants. Direct backing.
+- Chen et al 2024 (ReConcile) — multi-agent debate at N=3 with
+  **confidence-weighted voting**; voting is the aggregation layer.
+- Wang et al 2022 (Self-Consistency) — majority-vote aggregation
+  over sampled reasoning paths. Classical backing for voting-as-aggregation.
+- Condorcet 1785 (Condorcet Jury Theorem) — majority vote converges
+  on correct answer as N grows, under independence assumption. v2 single-vendor
+  limits independence (all experts are Claude Sonnet), so Condorcet is a
+  conceptual backstop, not a strong guarantee at v2. v3 multi-vendor will
+  strengthen this.
+
+**Risk if wrong:** Plurality with N=3 can tie (1-1-1 three-way). See
+D16 for handling.
+
+### D10 — Profile selection via `--profile` flag
+
+**What:** `--profile <file>` selects which profile to load (default:
+embedded `defaults/default.yaml` or local `./.council/default.yaml`
+via v1 loader precedence). With one shipped profile, `--profile` is
+rarely needed but preserves the v1 CLI contract for custom profiles.
+
+**Why:** Keeps v1 CLI compatibility. No new runtime dispatch logic —
+loader precedence is v1's established mechanism.
+
+**Alternatives considered:**
+- Remove `--profile` flag entirely (one profile, no need) — reduces
+  flexibility; operators with custom profiles would have to edit
+  the embedded default or use loader-precedence paths only. Rejected
+  for zero-cost flexibility.
+
+**Research:** None — preserves v1 behavior.
+
+**Risk if wrong:** Minor friction: operator who wants custom profile
+uses `--profile <path>` or drops it into `./.council/default.yaml`.
+Documented.
+
+### D11 — Per-session nonce for injection boundaries
+
+**What:** At session start, the orchestrator generates a 16-hex random
+nonce (from `crypto/rand`). 16 hex = 8 bytes = **64 bits of entropy**,
+sufficient under trusted-operator threat model. All prompt-fence
+delimiters in the session carry this nonce:
+
+```
+=== EXPERT: A [nonce-7c3f9a2b1d4e5f60] ===
+...
+=== END EXPERT: A [nonce-7c3f9a2b1d4e5f60] ===
+```
+
+Before an expert output is fed into a downstream prompt, it is scanned
+for the session nonce as a substring AND for a line-anchored fence
+regex. If either matches, the output is rejected.
+
+**Nonce scope — which prompt-construction sites are fenced:**
+- **ALL LLM-derived text is fenced with nonce** — expert outputs going
+  into R2+ aggregates, and into vote-ballot prompts.
+- The operator's question text is **NOT fenced** (it comes from the
+  operator, not LLM).
+- BUT: orchestrator scans operator question for any `=== ` line-anchored
+  fence pattern at load time; if found, exits with
+  `status: injection_suspected_in_question`, exit 1.
+- Rationale: fence everything LLM-sourced; trust operator input at the
+  boundary (per threat model), but sanity-check it.
+
+**Why:** Injection hardening was deferred from v1 to v2. Under our
+threat model (single-operator local tool, trusted Claude Code CLI as
+the only executor), the per-session nonce is sufficient: an attacker
+who does not know the nonce cannot forge a convincing fence.
+
+**Alternatives considered:**
+- Per-section sha256 hash — rejected as over-engineered under the
+  trusted-operator model. Noise in logs. Deferred to v3 if
+  multi-vendor untrusted executors arrive.
+- Plain ASCII fences (v1-style) — no forgery defense at all. Rejected.
+
+**Research:** No direct LLM-security research; we extend prior art
+(MAD, ReConcile both use plain fences) by adding a secret.
+
+**Risk if wrong:** If adversarial input ever appears (e.g., community
+executor for an untrusted LLM), the per-session nonce is weaker than
+per-section hashes. Clear upgrade path: introduce per-section hashes in
+v3 when needed.
+
+### D12 — One new Go package: `pkg/debate/`
+
+**What:** All debate-round logic — rounds, aggregate assembly,
+anonymization, voting — lives in `pkg/debate/`. Injection helpers are
+two functions in the existing `pkg/prompt/`.
+
+**Why:** Single cohesive state (rounds, votes, anonymization, session
+nonce, folder layout) lives together. No separate `pkg/vote`,
+`pkg/anonymize`, or `pkg/injection` packages — splitting would create
+cross-package coupling for no benefit.
+
+**Alternatives considered:**
+- Separate `pkg/vote/`, `pkg/anonymize/` — premature decomposition.
+- One package for everything including classifier (Round 4 design) —
+  classifier removed in Round 5; no longer applies.
+
+**Research:** Go project layout practice.
+
+**Risk if wrong:** `pkg/debate/` grows too large. Mitigation: split
+files within the package (debate/rounds.go, debate/vote.go,
+debate/anonymize.go), not new packages, unless a boundary becomes
+genuinely natural.
+
+### D14 — Explicit `council resume` subcommand
+
+**What:** v2 ships `council resume [--session <id>]` as a subcommand that finds an incomplete session folder and continues from the last completed stage. Default behavior: `council "question"` (no subcommand) always starts fresh; existing incomplete sessions are ignored. Operator must explicitly opt-in with `resume`.
+
+**Incomplete session predicate (finality-based, not verdict-existence-based):** A session is incomplete if:
+- The folder exists AND at least one `.done` marker somewhere below `rounds/` exists (something made progress), AND
+- The session is NOT final. A session is **final** if EITHER:
+  - Root-level `.done` marker exists (written after successful verdict write), OR
+  - `verdict.json.status ∈ {ok, no_consensus, quorum_failed_round_1, quorum_failed_round_2, injection_suspected_in_question, config_error}` — terminal statuses.
+
+  A session with a partial `verdict.json` whose `status == "interrupted"` (written on SIGINT per F6 + ADR-0008 F5) is NOT final and IS resumable. This is the primary advertised use case — operator hits Ctrl+C mid-R2, then runs `council resume` to pick up where the session stopped without losing sunk tokens.
+
+Empty folders and final sessions are skipped.
+
+**Resume algorithm:**
+1. Walk `./.council/sessions/` for incomplete sessions. Without `--session`, pick the newest; with `--session <id>`, pick the named folder. No match → exit 1 `no_resumable_session`.
+2. Load `profile.snapshot.yaml` and `question.md` from the folder — these are byte-for-byte the same as when the session started.
+3. Walk `rounds/N/experts/<label>/.done` markers to determine the last completed round and which experts in that round finished.
+4. Continue from the first incomplete stage: partial round (re-spawn missing experts only), next round, voting — in that order.
+5. Anonymization map is re-derived from `session_id` (deterministic, per D2).
+6. Per-session nonce is re-loaded from `profile.snapshot.yaml` (persisted there at session start).
+7. Append to the session folder; `verdict.json` is still atomically written at the end.
+
+**Why:** Long debate runs (K=2 + vote) take ~3–5 minutes and burn real tokens. SIGINT / network blip / rate-limit wall mid-run currently forces a full rerun. Resume makes the folder-as-database pattern carry its weight.
+
+**Alternatives considered:**
+
+- **Automatic resume on `council "q"` startup** — surprise behavior; operator expects fresh runs and gets a stale one silently. Rejected.
+- **Full checkpoint file (JSON state dump every N seconds)** — state already lives on disk via `.done` + `output.md` artifacts. A separate checkpoint file duplicates what the folder already is.
+- **Defer to v3 entirely** — operator value is high and implementation cost is modest (resume driver reads existing markers).
+
+**Research:** Git's `rebase --continue` / `merge --continue` pattern — explicit, operator-initiated, safe. Unix philosophy: one tool, one job, composable.
+
+**Risk if wrong:** Resume logic misdetects "incomplete" on e.g. a partially-written `output.md` from a SIGKILL mid-write. Mitigation: `.done` marker is the ONLY authority for "stage complete"; any stage without `.done` is re-run even if its `output.md` exists. Worst case: one extra LLM call for the questionable stage; no data loss since re-runs append fresh `.done` markers.
+
+### D15 — No judge (distributed decision via voting)
+
+**What:** v2 has no judge subprocess, no synthesis step, no polish
+step. The winning expert's R2 `output.md` is copied verbatim to
+`output.md` at session root.
+
+**Why:** A single judge creates a single point of model bias. The
+judge model's preferences — length bias, position bias, self-
+enhancement bias, writing-style bias — propagate into every verdict.
+Removing the judge distributes the final-answer decision across N
+experts (via voting, see D8). No single model dominates. This
+aligns with the "harmonious council of equals" design intent (no
+per-expert weights, no elevated judge role).
+
+Secondary benefit: we do not know empirically whether a polish step
+improves answer quality for our use case. YAGNI-строго: we don't
+build what we don't know we need. If raw expert output proves
+insufficient in practice, we add a polish step then, with knowledge
+of what it should do.
+
+**Alternatives considered:**
+- **Judge synthesizes final answer** (original Round 4 design) —
+  single-model bias concentrated in judge. Rejected per design
+  intent.
+- **Judge polishes winner's prose without changing substance**
+  (light-polish hybrid) — still introduces judge model's style
+  preferences; YAGNI says don't add unless proven needed.
+- **No aggregation, all experts' outputs returned** — loses the
+  signal that debate produced. Voting is the minimum aggregation
+  needed to select one answer.
+
+**Research:**
+- Panickssery et al 2024 — *LLM Evaluators Recognize and Favor Their Own Generations.*
+  Documents self-preference bias in LLM judges. Exactly the concern
+  that motivates removing the judge.
+- Zheng et al 2023 (*MT-Bench*) — judge-bias inventory (position,
+  verbosity, self-enhancement). Catalogues biases a single judge
+  introduces; distributed voting avoids them.
+- Du et al 2024 — multiagent debate uses majority voting as the
+  aggregation mechanism in multiple reported variants (not only
+  judge synthesis). Voting-without-judge is research-supported.
+
+**Risk if wrong:** Raw expert R2 text may be rough, overly technical,
+or ill-structured for user consumption compared to judge-polished
+prose. Mitigation: if this proves problematic in practice, a polish
+step can be added later with a narrow contract ("clean prose, do not
+change substance"). Until then, quality-first tolerance says ship
+the authentic expert answer.
+
+### D16 — Tie handling: surface all, no tiebreak (YAGNI)
+
+**What:** On a three-way tie (1-1-1 vote split, only possible at N=3),
+all three R2 outputs are surfaced to the operator as separate files:
+`output-A.md`, `output-B.md`, `output-C.md`. The verdict records
+`voting.tied_candidates = ["A", "B", "C"]`. Exit code 2
+`no_consensus`. No tiebreak mechanism.
+
+**Why:** YAGNI-строго. We do not know if 1-1-1 ties occur often
+enough to warrant automated tiebreak logic. We do not know which
+tiebreak algorithm would be correct (seed-based hash? extra debate
+round? random? judge?). All four have been considered and none is
+obviously right.
+
+Instead: report the tie honestly, surface all tied answers, let the
+operator decide. When we have operational data showing ties are
+frequent enough to automate, we'll add a tiebreak mechanism informed
+by the actual distribution and operator needs. Until then: do not
+build.
+
+**Alternatives considered:**
+- **Seed-based tiebreak** (`sha256(session_id + ":tiebreak") mod len(tied)`) —
+  reproducible, zero-cost, but arbitrary. Rejected per YAGNI until
+  we know ties matter.
+- **Extra debate round + revote** — adds 2-3× cost on tied sessions.
+  May still tie. Rejected per YAGNI.
+- **Judge picks among tied** — reintroduces judge (contradicts D15).
+  Rejected.
+- **Random tiebreak** — not reproducible. Rejected for v1 reproducibility
+  principle.
+
+**Research:** None — pure YAGNI design choice. The absence of research
+is part of the rationale: no paper prescribes a universal tiebreak for
+multi-agent debate at N=3 with 1-1-1 splits.
+
+**Risk if wrong:** If 1-1-1 ties turn out to be common in practice,
+operators may find exit-2 + three files annoying. Mitigation: we'll
+learn from use and add a tiebreak then with knowledge of what's
+correct. Low-risk deferral — the ties are visible in the verdict
+and operator can always pick one of the three.
+
+## 5. What v2 Does NOT Build (deferred to v3)
+
+- **Multi-vendor executors** — Codex, Gemini, other CLIs. v2 is
+  single-vendor (Claude Code).
+- **Classifier / type branching** — Round 5 removed; one single flow
+  for all questions. If structured output (vote tallies, factual
+  disputes) ever becomes a real need, v3 can reintroduce a branch.
+- **Judge / synthesis / polish step** — removed per D15; may return
+  as narrow "prose polish" step in v3 if raw expert output proves
+  insufficient.
+- **Tournament / self-defense** — removed per Round 5. See
+  superseded ADR-0009 for historical rationale.
+- **FACT:/SOURCE: contract for factual questions** — removed per
+  Round 5. If automated fact-checking is ever built, it's a v3
+  path alongside the current debate+vote flow, not inside it.
+- **Structured verdict fields** — `verdict.json.voting.tally` is
+  present but v2's flow doesn't populate detailed structured
+  outputs (vote distributions are simple counts; no factual
+  equivalence classes).
+- **Tiebreak on 1-1-1 votes** — per D16 YAGNI; added when operational
+  data shows it's needed.
+- **Adversarial / devil's-advocate agent role** — config has a `role:`
+  hook, no implementation.
+- **Ensemble judge** — N/A in v2 (no judge).
+- **Adaptive convergence** — early-exit on consensus.
+- **Automatic resume on startup** — `council resume` is explicit-only in
+  v2 per D14; automatic detection on `council "q"` is deferred.
+- **Per-section sha256 injection boundaries** — upgrade from per-session
+  nonce.
+- **Confidence-weighted voting** — LLM confidence is poorly calibrated
+  (Xiong 2024); deferred until we have calibration data.
+- **Ranked / Borda / Schulze voting** — plurality-only in v2.
+- **Ranking / rating / numerical-estimation modes** — distinct
+  aggregation; each a v3 candidate.
+- **Wall-clock `--deadline` flag** — per-round timeouts only.
+- **`council gc` subcommand** for session-folder rotation — operator
+  uses `find` + `rm` until v3.
+- **Strict-participation mode** (`--strict` flag) — abort if any expert
+  fails instead of carry-forward.
+- **Summary compression between rounds** — rejected per Ninja's
+  "не экономим токены" preference; raw peer outputs carry forward.
+
+## 6. Research Map
+
+Each decision in §4 cites sources. This table lists the sources, which
+decision they back, and their verification status (checked during
+research phase).
+
+| # | Paper / Source | arXiv / Ref | Backs | Verified |
+|---|---|---|---|---|
+| 1 | Du, Li, Torralba, Tenenbaum, Mordatch. *Improving Factuality and Reasoning through Multiagent Debate.* ICML 2024 | [2305.14325](https://arxiv.org/abs/2305.14325) | D1 blind-R1, D5 round-count, **D8 voting aggregation** | ✓ |
+| 2 | Chen, Saha, Bansal. *ReConcile: Round-Table Conference Improves Reasoning.* ACL 2024 | [2309.13007](https://arxiv.org/abs/2309.13007) | D2 stable anonymization, **D8 vote aggregation** | ✓ |
+| 3 | Panickssery, Bowman, Feng. *LLM Evaluators Recognize and Favor Their Own Generations.* | [2404.13076](https://arxiv.org/abs/2404.13076) | **D15 no-judge (primary)** | ✓ |
+| 4 | Zheng et al. *Judging LLM-as-a-Judge with MT-Bench.* NeurIPS 2023 | [2306.05685](https://arxiv.org/abs/2306.05685) | **D15 no-judge (primary — judge-bias inventory)** | ✓ |
+| 5 | Wang et al. *Self-Consistency Improves Chain of Thought.* | [2203.11171](https://arxiv.org/abs/2203.11171) | **D8 voting aggregation (primary)** | ✓ |
+| 6 | Wei et al. *Simple Synthetic Data Reduces Sycophancy.* | [2308.03958](https://arxiv.org/abs/2308.03958) | D1/D2 implicit mind-change, no "do you want to change?" prompt | ✓ |
+| 7 | Huang et al. *Large Language Models Cannot Self-Correct Reasoning Yet.* | [2310.01798](https://arxiv.org/abs/2310.01798) | Same as #6 | ✓ |
+| 8 | Dalkey. *The Delphi Method.* RAND RM-5888-PR, 1969 | RAND | D2 classical anonymization rationale | ✓ |
+| 9 | Condorcet, 1785. Condorcet Jury Theorem | classical | **D8 voting-aggregation conceptual backstop (v2 single-vendor caveat on independence)** | ✓ classical |
+| 10 | Arrow 1951. *Social Choice and Individual Values.* | classical | Conceptual backstop for voting limits (frames the impossibility of a perfect ranked-preference aggregation for v3 ranking mode) | ✓ classical |
+
+### Citations retained in ADR history (superseded)
+
+These citations backed Round 4 decisions that Round 5 superseded. They
+remain in the respective ADR files for historical record:
+
+- **Irving, Christiano, Amodei 2018** — *AI Safety via Debate.*
+  Backed D9 tournament framework. Retained in superseded ADR-0009.
+- **Khan, Hughes et al 2024** — *Debating with More Persuasive LLMs.*
+  Backed D9 tournament scales with capability. Retained in superseded
+  ADR-0009.
+- **Xiong et al 2024** — *Can LLMs Express Their Uncertainty?* Backed
+  D4 classifier-confidence calibration caveat. Retained in superseded
+  ADR-0007.
+
+### Claims flagged during research
+
+- **No paper empirically compares "debate → vote" vs
+  "debate → judge-synthesis" head-to-head on open-ended writing
+  questions.** Du et al 2024 uses both variants but on
+  classification/reasoning tasks, not open-ended prose. This is a
+  genuine gap. The simplified design is research-supported but not
+  research-proven superior to judge-synthesis for our specific
+  use case. We accept this honestly; if operational experience shows
+  problems, v3 can revisit.
+
+- **Liang et al 2305.19118** was NOT about "devil's advocate" as stated
+  in earlier messages — its actual contribution is the "Degeneration-of-
+  Thought" phenomenon and "tit-for-tat" debate structure. The
+  adversarial-role concept is instead drawn from Skytliang's MAD
+  implementation.
+
+- **Pham et al 2310.06272** is NOT about "mimicry collapse" in multi-
+  agent debate. Its actual contribution is comparing natural-language
+  tokens vs. embedding communication between agents. We dropped it as a
+  citation source entirely; the mimicry-collapse concern is documented
+  from operational observation, not this paper.
+
+## 7. Success & Failure
+
+### 7.1 Success criteria
+
+- **Answer quality** on reasoning-heavy questions visibly improves over
+  v1 (subjective evaluation at first; a proper benchmark is v3).
+- **No single-model bias in aggregation** — voting distributes the
+  final decision across all N experts, not a single judge.
+- **One binary**, no new runtime dependencies beyond v1 (v2 reuses v1's `golang-petname` for session IDs; `crypto/sha256`, `crypto/rand`, and `math/rand/v2` are stdlib).
+- **Session folder reproducibility**: a session folder can be tarred,
+  moved, and replayed for debugging.
+- **v1 compatibility**: v1 `default.yaml` + `rounds: 2` addition is
+  valid v2 config. v1 users migrate by adding one line.
+- **`verdict.json.version` is bumped from `1` to `2`** in all v2 runs.
+
+### 7.2 Known failure modes and limitations
+
+- **Token budget amplification** — debate at K=2 with N=3 consumes
+  roughly 3–5× the tokens of a v1 run. Documented in README and
+  observable via `verdict.json.*.duration_seconds`.
+- **Style leak through anonymization (R-v2-06)** — an expert's
+  signature phrases may reveal its real identity across rounds
+  (e.g., specific Claude phrasings). During voting, this could
+  let experts identify and prefer their own answer. Accepted as
+  known limitation; style-anonymization is v3.
+- **Debate drift (R-v2-07)** — at K > 2, experts start parroting
+  the previous round's consensus (mimicry collapse). Default K=2
+  sidesteps this; operators who set K=3+ are on their own.
+- **Raw expert output may be rougher than judge-polished prose** —
+  known trade-off of D15 (no judge). If problematic in practice,
+  v3 may add a narrow polish step.
+- **Three-way tie surfaces all answers** — D16 YAGNI choice.
+  Operator must pick from three outputs when ties occur.
+- **Single-vendor executors** — v2 runs only on Claude Code; heterogeneous
+  executor pools (Codex, Gemini) are v3. Condorcet's independence
+  assumption is only weakly satisfied at v2.
+
+### 7.3 Exit Codes (v2)
+
+| Code | Meaning | Introduced |
+|---|---|---|
+| 0 | success (clear winner, winner's R2 text returned) | v1 |
+| 1 | config/input error, `injection_suspected_in_question` | v1 (extended) |
+| 2 | quorum_failed, `quorum_failed_round_N`, **`no_consensus` (1-1-1 tie)** | v1 (extended) |
+| 130 | SIGINT / interrupted | v1 |
+
+Notes:
+- **No exit code 3** — there is no judge to fail (D15).
+- **No exit code 4** — there is no classifier to fail (Round 5
+  simplification; see superseded ADR-0007).
+- **1-1-1 tie is exit 2** `no_consensus` — the run completed all
+  stages but voting produced no plurality winner. Tied outputs
+  are surfaced per D16.
+
+### 7.4 What failure-handling v2 deliberately does NOT do
+
+- **Automatic resume** after a crashed run — `council resume` is
+  explicit-only (D14).
+- **Distributed / multi-host** runs.
+- **Canary rollout** or gradual feature flags.
+- **Tiebreak on 1-1-1** — YAGNI per D16.
+
+## 8. Fitness Functions
+
+Structural gates the v2 implementation must satisfy. Each has a
+concrete test hook.
+
+| # | Fitness | Concrete check |
+|---|---|---|
+| F1 | v1 exit codes still work | `council "q"` exits 0 on success |
+| F2 | Session folder format | `rounds/{1,2}/experts/<label>/` + `voting/` + `verdict.json` at session root |
+| F3 | Verdict version bumped | `jq -e '.version == 2' verdict.json` |
+| F4 | Anonymization consistency | F8 below — same label → same real name across all rounds |
+| F5 | Nonce fence present | All LLM-sourced fence lines match `\[nonce-[0-9a-f]{16}\]$` |
+| F6 | SIGINT yields partial verdict | Anonymization map present even on Ctrl+C |
+| F7 | Carry-forward recorded | `jq -e '.experts[].participation_by_round \| length == .rounds' verdict.json` |
+| F8 | Anonymization map resolves uniformly | `jq -e '.anonymization as $m \| [.rounds[].experts[] \| {label, real_name}] \| unique \| all(. as $e \| $m[$e.label] == $e.real_name)' verdict.json` |
+| F9 | Injection scan rejects forged fence | Unit tests: forged expert outputs containing (a) fake open fence `=== EXPERT: A [nonce-...]`, (b) fake close fence `=== END EXPERT: A`, (c) fake global fence `=== CANDIDATES ===` or `=== END CANDIDATES ===`, (d) fake open fence with a wrong nonce — all rejected, expert marked failed |
+| F12 | Vote produces tally or tied-candidates | `jq -e '.voting.winner or .voting.tied_candidates' verdict.json` — exactly one of these fields is populated per run |
+
+F10 and F11 were retired in Round 5 (they covered classifier and
+tournament — removed features).
+
+## 9. Relationship to Derivatives
+
+This document is the source. The derivatives are regenerated when
+decisions here change:
+
+1. **`docs/plans/2026-04-22-v2-debate-engine.md`** — ralphex implementation plan (12 tasks, TDD-first, with session-folder layout, verdict.json v2 schema, fitness-function test hooks, and acceptance-verification task). Rendered from the decisions in §4.
+2. **`docs/adr/0007-classifier-selects-per-type-profile.md`** —
+   superseded ADR; retained for historical record.
+3. **`docs/adr/0008-debate-rounds-anonymization-injection.md`** — ADR
+   merging D1, D2, and D11.
+4. **`docs/adr/0009-tournament-self-defense.md`** — superseded ADR;
+   retained for historical record.
+5. **`defaults/default.yaml`** and **`defaults/prompts/*.md`** —
+   runtime artifacts reflecting D5, D6, D8, D10.
+
+### Workflow
+
+1. Ninja edits this document (adds / removes / changes D-decisions or the
+   §5 deferred list).
+2. Minime regenerates the derivatives above, confirming structural and
+   coverage gates pass.
+3. Derivatives are committed together with this document in one PR.
+
+The ralphex plan (`docs/plans/2026-04-22-v2-debate-engine.md`) should never contradict this document. If it does, this document wins; the plan is regenerated.
+
+## 10. Open Questions / Future Research
+
+None at the time of writing. When new questions arise (either during
+implementation or after real runs), they live here until resolved, then
+move into a decision above.
+
+---
+
+**Status:** **Accepted** (Round 5 simplification — signed off by Ninja on 2026-04-21. v2 reframed to single debate+vote flow; no classifier, no judge, no tournament, no factual path. Rationale: dialectic review surfaced that vote/factual paths' primary value was structured machine-readable output, which v2 does not need. Further iteration removed the judge entirely to eliminate single-model bias in aggregation; voting distributes the final decision across N experts. YAGNI-строго principle applied: no polish, no tiebreak, no speculative features. Quality-first tolerance principle applied: carry-forward on R2 failure retained. ADRs 0007 and 0009 marked superseded with history preserved.)
+**Last updated:** 2026-04-21
+**Companion PR:** #2

--- a/docs/plans/2026-04-22-v2-debate-engine.md
+++ b/docs/plans/2026-04-22-v2-debate-engine.md
@@ -1,0 +1,326 @@
+# v2 Debate Engine — Implementation Plan
+
+## Overview
+
+Implement the v2 debate engine on top of the v1 MVP code. v2 adds multi-round anonymized debate (blind R1 + peer-aware R2) followed by distributed voting among N experts. Winner's R2 text is returned verbatim; on 1-1-1 three-way tie, all tied outputs are surfaced. No classifier, no judge, no tournament.
+
+The Round 5 simplified design removes single-model bias by eliminating the judge role — voting distributes the final decision across all experts (D15). A 16-hex per-session nonce stops forged-fence injection across the LLM-output boundary (D11, ADR-0008). An explicit `council resume` subcommand (D14) lets operators continue interrupted sessions without full reruns.
+
+**Net v2 delta vs v1:** debate rounds + anonymization + nonce + vote stage + resume. Single profile, single flow.
+
+## Context (from discovery)
+
+- **Source of truth:** `docs/design/v2.md` (§3 decisions D1–D3, D5–D8, D10–D12, D14–D16; §5 research map; §6 success criteria and exit codes; §7 fitness functions).
+- **Technical spec derivative:** `docs/plans/v2-debate-engine.md` — has the detailed schema, folder layout, orchestration algorithm, verdict shape.
+- **ADRs:** ADR-0008 (accepted, debate rounds + anonymization + nonce). ADR-0007 and ADR-0009 are superseded — read them only for history.
+- **v1 code base** (already on main via PR #3, `feat/v1-mvp-implementation`):
+  - `pkg/config/` — loader, embedded FS, snapshot
+  - `pkg/session/` — session ID, folder ops, verdict.WriteAtomic
+  - `pkg/runner/` — subprocess runner (process-group kill, retries, 429 handling)
+  - `pkg/executor/` — Executor interface, claude-code impl, registry
+  - `pkg/prompt/` — expert + judge prompt builders (accepts optional `prior_rounds` — forward-compat hook for v2)
+  - `pkg/orchestrator/` — single-pass fan-out, quorum, judge, verdict assembly
+  - `cmd/council/` — CLI entry
+  - `defaults/` — embedded v1 `default.yaml` + prompts
+  - `test/smoke/` — F1–F7 smoke suite
+- **New package to create:** `pkg/debate/` — rounds, anonymization, voting. Internal file split: `anonymize.go`, `rounds.go`, `vote.go`.
+- **Key contracts to preserve:**
+  - v1 CLI (council "q", -p, --profile, -, -v) still works
+  - Executor interface unchanged
+  - pkg/runner unchanged (process-group kill, 429 retry)
+  - Atomic verdict.json write unchanged
+  - Folder-as-database (ADR-0003)
+
+## Development Approach
+
+- **Testing approach: TDD** — tests first, see them fail, implement, see them pass.
+- Complete each task fully before moving to the next.
+- Make small, focused changes.
+- **CRITICAL: every task MUST include new/updated tests** for code changes in that task.
+- **CRITICAL: all tests must pass before starting next task** — no exceptions.
+- **CRITICAL: update this plan file when scope changes during implementation.**
+- Run tests after each change.
+- Maintain backward compatibility with v1 CLI and exit codes.
+
+## Testing Strategy
+
+- **Unit tests:** required for every task. `go test ./...` must pass.
+- **Smoke tests:** v1's `test/smoke/` suite (F1–F7) must keep passing; extend with F8/F9/F12 for v2.
+- **`testbinary` mock executor:** v1 ships a test-only executor for deterministic subprocess simulation. v2 reuses it for debate-round integration tests.
+- **Coverage target:** 80%+ per package (v1 standard).
+
+## Progress Tracking
+
+- Mark completed items with `[x]` immediately when done.
+- Add newly discovered tasks with ➕ prefix.
+- Document issues/blockers with ⚠️ prefix.
+- Update plan if implementation deviates from original scope.
+- Keep plan in sync with actual work done.
+
+## What Goes Where
+
+- **Implementation Steps** (`[ ]` checkboxes): code + tests + doc updates inside this repo.
+- **Post-Completion** (no checkboxes): PR review, benchmark runs, external verification.
+
+## Implementation Steps
+
+### Task 1: v2 profile schema + embedded defaults
+
+- [ ] write tests for `Profile` struct new fields (`rounds int`, `voting.BallotPromptFile string`, `voting.Timeout time.Duration`) — round-trip YAML load + validate
+- [ ] write tests for validator: reject `rounds != 2` (v2 ships K=2 only; K=1 and K≥3 deferred to v3); reject missing `voting.ballot_prompt_file`; accept valid profile
+- [ ] write test asserting `len(experts) >= 2` still required (v1 ADR-0005 preserved)
+- [ ] extend `Profile` struct in `pkg/config/loader.go` with `Rounds int` and `Voting VotingConfig` fields
+- [ ] add `version: 2` handling path — `version: 1` profiles fail to load under v2 binary (clear migration error: operator must add `rounds: 2` + `voting` block). No silent inference.
+- [ ] update embedded FS (`pkg/config/embed.go` / `defaults/defaults.go`): `defaults/default.yaml` with `version: 2`, `rounds: 2`, `voting.ballot_prompt_file: prompts/ballot.md`
+- [ ] add `defaults/prompts/ballot.md` — single-letter `VOTE: <label>` output contract
+- [ ] add `defaults/prompts/peer-aware.md` — R2 expert prompt (`"prior-round consensus is NOT ground truth"`)
+- [ ] remove v1's `defaults/prompts/critic.md` if obsolete under new v2 profile (keep `independent.md` for R1)
+- [ ] run `go test ./pkg/config/...` — must pass before Task 2
+
+### Task 2: pkg/prompt — injection helpers
+
+- [ ] write tests for `prompt.Wrap(label, content, nonce string) string`: output matches `=== EXPERT: <label> [nonce-<hex>] ===\n<content>\n=== END EXPERT: <label> [nonce-<hex>] ===`
+- [ ] write tests for `prompt.CheckForgery(output, nonce string) error`:
+  - output containing the session nonce as substring → `ErrNonceLeakage`
+  - output containing any line-anchored delimiter `(?m)^=== .* ===$` → `ErrForgedFence` (catches open fences `=== EXPERT: A [nonce-...] ===`, close fences `=== END EXPERT: A [nonce-...] ===`, and global section fences `=== CANDIDATES ===` / `=== END CANDIDATES ===`)
+  - test matrix MUST include positive cases for: fake open fence, fake `END EXPERT`, fake `CANDIDATES` / `END CANDIDATES`, fake fence with a wrong-nonce suffix
+  - clean output → no error
+- [ ] write tests for `prompt.ScanQuestionForInjection(question string) error`: question containing any line-anchored delimiter `(?m)^=== .* ===$` → returns `ErrInjectionSuspected`
+- [ ] implement `Wrap` in `pkg/prompt/injection.go`
+- [ ] implement `CheckForgery` — substring check for nonce + broad delimiter-line regex `(?m)^=== .* ===$` rejecting all delimiter-shaped lines regardless of content
+- [ ] implement `ScanQuestionForInjection` using same delimiter-line regex
+- [ ] export sentinel errors (`ErrNonceLeakage`, `ErrForgedFence`, `ErrInjectionSuspected`)
+- [ ] run `go test ./pkg/prompt/...` — must pass before Task 3
+
+### Task 3: pkg/debate — anonymization
+
+- [ ] write tests for `AssignLabels(sessionID string, experts []Expert) map[string]string`:
+  - deterministic: same sessionID + same experts → same mapping (run twice, assert equal)
+  - shuffle happens: for different sessionIDs, mapping varies
+  - labels are `A, B, C, …` in the shuffled order
+  - N=3 case: returns exactly 3 entries mapping single-letter labels to real names
+- [ ] create `pkg/debate/anonymize.go`
+- [ ] implement `AssignLabels`: compute `digest := sha256.Sum256([]byte(sessionID))`; derive `seedHi := binary.BigEndian.Uint64(digest[0:8])`, `seedLo := binary.BigEndian.Uint64(digest[8:16])`; `rng := rand.New(rand.NewPCG(seedHi, seedLo))`; shuffle experts via `rng.Shuffle`; assign labels A, B, C in shuffled order
+- [ ] constrain N ≤ 26 (return error if exceeded — v3 extension via `A1, A2, …` deferred)
+- [ ] export reverse-lookup helper `LabelOf(real string, mapping map[string]string) (label string, ok bool)` for orchestrator convenience
+- [ ] run `go test ./pkg/debate/...` — must pass before Task 4
+
+### Task 4: pkg/debate — session nonce generation + snapshot persistence
+
+- [ ] write test: `GenerateNonce() string` returns 16 lowercase hex chars `[0-9a-f]{16}`; different calls return different nonces (high-probability assertion, 8-byte entropy)
+- [ ] write test: nonce is persisted in `profile.snapshot.yaml` via `pkg/session` (extend session snapshot loader to include `session_nonce`)
+- [ ] implement `pkg/debate.GenerateNonce()` using `crypto/rand.Read(8 bytes)` + hex encode
+- [ ] extend `pkg/session/session.go` snapshot writer to include `session_nonce` field in `profile.snapshot.yaml`
+- [ ] extend `pkg/session/session.go` snapshot loader (`LoadSnapshot`) to re-read `session_nonce` (for resume in Task 11)
+- [ ] run `go test ./pkg/debate/... ./pkg/session/...` — must pass before Task 5
+
+### Task 5: pkg/debate — R1 blind fan-out
+
+- [ ] write test for `RunRound1(ctx, cfg RoundConfig, question string) ([]RoundOutput, error)` using `executor/mock`:
+  - N=3 experts, all succeed → returns 3 RoundOutputs with `Participation == "ok"`
+  - one expert times out, retries exhausted → dropped, `Participation == "failed"`
+  - one expert produces output containing the session nonce → rejected, marked failed
+  - output written to `rounds/1/experts/<label>/output.md` per surviving expert
+  - `.done` marker written only for successful experts
+- [ ] write test: `surviving_count < quorum` → `RunRound1` returns a specific error (`ErrQuorumFailedR1`) so orchestrator can exit 2
+- [ ] create `pkg/debate/rounds.go` — `RunRound1` function signature + implementation
+- [ ] use existing `pkg/runner` primitive for subprocess spawn (DO NOT duplicate)
+- [ ] wire forgery check via `prompt.CheckForgery` — on match, treat expert as failed for this round
+- [ ] write session-folder artifacts via `pkg/session` helpers (DO NOT duplicate folder creation)
+- [ ] run `go test ./pkg/debate/...` — must pass before Task 6
+
+### Task 6: pkg/debate — R2 peer-aware fan-out + carry-forward
+
+- [ ] write test for `RunRound2(ctx, cfg RoundConfig, question string, r1 []RoundOutput) ([]RoundOutput, error)` using `executor/mock`:
+  - peer aggregate for each expert excludes self; orders alphabetically by label
+  - each peer output is wrapped via `prompt.Wrap` with session nonce
+  - expert fails in R2 → R1 output copied to `rounds/2/experts/<label>/output.md`, `Participation == "carried"`
+  - expert succeeds → R2 output written, `Participation == "ok"`
+  - surviving_count < quorum after R2 → `ErrQuorumFailedR2`
+- [ ] write test: R2 aggregate file `rounds/2/aggregate.md` is written ONCE after final R2 completes, contains all surviving experts' R2 outputs wrapped with nonce, ordered alphabetically by label
+- [ ] implement `RunRound2` in `pkg/debate/rounds.go`
+- [ ] implement `buildPeerAggregate(forLabel string, outputs []RoundOutput, nonce string) string` helper — excludes `forLabel`, orders alphabetically, wraps each with `prompt.Wrap`
+- [ ] implement `writeGlobalAggregate(session *Session, round int, outputs []RoundOutput, nonce string) error` — writes `rounds/N/aggregate.md`
+- [ ] run `go test ./pkg/debate/...` — must pass before Task 7
+
+### Task 7: pkg/debate — voting stage
+
+- [ ] write tests for `RunBallot(ctx, cfg BallotConfig, question, aggregateMD string) ([]Ballot, error)`:
+  - N=3 experts all produce `VOTE: A` / `VOTE: B` / `VOTE: C` → 3 Ballots
+  - malformed ballot (no VOTE line) → voter's ballot discarded, NOT a run failure
+  - ballot votes for non-existent label (e.g., votes `D` when only A/B/C survived) → discarded
+  - ballot is a fresh subprocess (no prior-round context) — verified by checking prompt passed to mock executor
+- [ ] write tests for `Tally(ballots []Ballot, activeLabels []string) TallyResult` — general form (see design D8):
+  - **Full cohort:** 3-0-0 → `Winner == "A"`, `TiedCandidates == nil`; 2-1-0 → unique winner; 1-1-1 → `Winner == ""`, `TiedCandidates == ["A","B","C"]` (sorted)
+  - **Reduced cohort (N=2 post-R1-drop):** 2-0 → unique winner; 1-1 → `TiedCandidates == ["A","B"]`
+  - **Malformed ballots discarded:** 3 votes with 1 malformed → tally from 2 valid ballots; if they split 1-1 → tie; if they agree 2-0 → winner
+  - **All malformed (zero valid ballots):** every active label is "tied at max zero" → `TiedCandidates` lists every active label; `Winner == ""`
+  - invariant: if `TiedCandidates != nil`, every listed label is in `activeLabels` and has the max vote count (possibly zero)
+- [ ] write tests for `SelectOutput(session *Session, result TallyResult, r2 []RoundOutput) error`:
+  - unique winner → copies winner's `rounds/2/experts/<winner>/output.md` to session root `output.md`
+  - N-way tie (any N ≥ 2 tied candidates) → copies each tied label's R2 output to `output-<label>.md` (e.g., `output-A.md`, `output-B.md`, ...)
+- [ ] create `pkg/debate/vote.go` with `RunBallot`, `Tally`, `SelectOutput`
+- [ ] ballot parser regex: `(?m)^VOTE: ([A-Z])$` with active-label validation
+- [ ] Tally iteration order must be stable: sort active labels alphabetically before computing max (determinism)
+- [ ] write `voting/tally.json` and per-voter `voting/votes/<voter-label>.txt` via `pkg/session`
+- [ ] run `go test ./pkg/debate/...` — must pass before Task 8
+
+### Task 8: Orchestrator integration
+
+- [ ] write integration test in `pkg/orchestrator/orchestrator_test.go` using `executor/mock`:
+  - happy path: N=3, K=2, all succeed → session folder has rounds/1, rounds/2, voting/, output.md, verdict.json with `status: ok`
+  - one expert fails R1 → quorum=1 still satisfied, run continues with N=2 through R2 + vote
+  - 1-1-1 tie → output-A.md + output-B.md + output-C.md present, exit 2 `no_consensus`
+  - injection in question → exit 1 `injection_suspected_in_question`
+- [ ] extend `pkg/orchestrator/orchestrator.go` `Run()`:
+  - session setup (session_id, nonce, anonymization, snapshot write, question sanity scan)
+  - R1 via `debate.RunRound1`
+  - quorum check after R1
+  - R2 via `debate.RunRound2` (if K >= 2)
+  - quorum check after R2
+  - write global aggregate
+  - vote via `debate.RunBallot`
+  - tally + output selection
+  - verdict write (atomic)
+  - **root-level `.done` marker written AFTER verdict.json lands** — this marker is the finality signal consumed by `council resume` (D14). SIGINT handler must NOT write root `.done`; it writes `verdict.json` with `status: "interrupted"` only.
+- [ ] preserve v1 exit codes; add exit 2 `no_consensus` for tie; no exit 3 (no judge); no exit 4 (no classifier)
+- [ ] run `go test ./pkg/orchestrator/...` — must pass before Task 9
+
+### Task 9: verdict.json v2 schema
+
+- [ ] write test for verdict v2 shape (matches `docs/plans/v2-debate-engine.md` §12):
+  - `version == 2`
+  - `rounds` array with per-round expert entries (label, real_name, participation, duration)
+  - `experts[].participation_by_round` equals `(.rounds | length)` array of `ok`/`carried`/`failed`
+  - `voting.votes` object, `voting.winner` OR `voting.tied_candidates` (exactly one)
+  - `voting.ballots` array of {voter_label, voted_for}
+  - `anonymization` map `{label: real_name}`
+  - `status == "ok"` or `"no_consensus"`
+- [ ] write fitness F8 assertion test: anonymization consistency — every (label, real_name) in rounds[] matches anonymization map
+- [ ] write fitness F12 test: exactly one of `voting.winner` / `voting.tied_candidates` is populated
+- [ ] write fitness F7 test: `participation_by_round | length == (.rounds | length)` (K-agnostic)
+- [ ] extend `pkg/session/verdict.go` with v2 shape (add `VerdictV2` struct or extend existing with `version: 2`)
+- [ ] atomic write via `pkg/session/verdict.WriteAtomic` preserved
+- [ ] run `go test ./pkg/session/... ./pkg/orchestrator/...` — must pass before Task 10
+
+### Task 10: `council resume` subcommand (D14)
+
+- [ ] write tests for `pkg/session.FindIncomplete(root string) (sessionPath string, err error)` — finality-based predicate per design D14:
+  - no folders → `ErrNoResumableSession`
+  - folder with root-level `.done` marker → skipped (final)
+  - folder with `verdict.json.status ∈ {ok, no_consensus, quorum_failed_round_1, quorum_failed_round_2, injection_suspected_in_question, config_error}` → skipped (final)
+  - folder with no .done markers anywhere → skipped (nothing progressed)
+  - folder with `rounds/1/experts/A/.done` but no verdict.json → **returned** (resumable)
+  - folder with partial `verdict.json.status == "interrupted"` + stage `.done` markers → **returned** (resumable; this is the SIGINT-mid-run case that F6 + ADR-0008 F5 expect to resume)
+  - multiple resumable → newest wins
+- [ ] write tests for `pkg/session.LoadExisting(path string) (*Session, error)`: re-derives anonymization from session_id, re-reads session_nonce from snapshot, restores profile + question
+- [ ] write integration test for resume:
+  - full run crashes after R2 (simulate via mock executor returning "success" for R1/R2 experts but kill before vote) — resume should run only the vote stage + finalize
+  - crash mid-R2 (one expert done, others not) — resume re-spawns missing experts in R2
+  - **SIGINT mid-R2 with partial verdict.json** — send SIGINT while R2 experts are running; v1 SIGINT handler writes `verdict.json` with `status: "interrupted"` + anonymization map; resume must pick this session up despite verdict.json existing (verifies finality-not-existence predicate)
+- [ ] implement `FindIncomplete` in `pkg/session/resume.go`
+- [ ] implement `LoadExisting` in `pkg/session/resume.go`
+- [ ] add `resume` subcommand to `cmd/council/main.go` with `--session <id>` flag
+- [ ] wire resume path: determine first incomplete stage, call appropriate `debate.*` function with previously-loaded state, continue to finalize
+- [ ] exit 1 `no_resumable_session` if nothing to resume
+- [ ] run `go test ./pkg/session/... ./cmd/council/...` — must pass before Task 11
+
+### Task 11: Smoke test suite + documentation updates
+
+- [ ] extend `test/smoke/smoke_test.go` with F8 (anonymization consistency), F9 (forgery detection via unit test), F12 (vote outcome) assertions
+- [ ] update `test/smoke/run.sh` or equivalent to exercise v2 flows (happy path + tie path + resume path)
+- [ ] verify smoke suite passes: `go test -tags=smoke ./test/smoke/...`
+- [ ] update `README.md`: v2 is a debate engine; `council "q"` runs R1+R2+vote; `council resume` exists; bump version bullet (v2 bumps `verdict.json.version` to 2)
+- [ ] update `README.md` CLI examples — remove references to v1 single-pass phrasing where it misleads
+- [ ] add a "what's new in v2" paragraph pointing at `docs/design/v2.md`
+- [ ] run full suite: `go test ./... && go test -tags=smoke ./test/smoke/...`
+
+### Task 12: Verify acceptance criteria
+
+- [ ] verify all D1–D3, D5–D8, D10–D12, D14–D16 decisions from `docs/design/v2.md` §3 are reflected in code (map each decision → relevant test)
+- [ ] verify fitness functions F1–F8, F9, F12 from `docs/plans/v2-debate-engine.md` §15 all have tests
+- [ ] verify exit codes match `docs/plans/v2-debate-engine.md` §13 (0 / 1 / 2 / 130; no 3 or 4)
+- [ ] run full test suite one more time
+- [ ] run linter (`golangci-lint run` or `go vet ./...`) — all issues resolved
+- [ ] verify test coverage ≥ 80% in new pkg/debate and modified pkg/orchestrator, pkg/session, pkg/prompt, pkg/config packages (use `go test -cover`)
+- [ ] scan for TODOs / FIXMEs introduced by implementation — resolve or file follow-ups
+
+## Technical Details
+
+### Session folder layout (v2 extension of v1)
+
+```
+.council/sessions/<petname-id>/
+├── question.md
+├── profile.snapshot.yaml      # includes session_nonce field
+├── rounds/
+│   ├── 1/experts/<A|B|C>/{prompt.md, output.md, stderr.log, .done}
+│   └── 2/
+│       ├── experts/<A|B|C>/{prompt.md, output.md, stderr.log, .done}
+│       └── aggregate.md        # global aggregate of all R2 outputs (ballot input)
+├── voting/
+│   ├── votes/<A|B|C>.txt       # "VOTE: B"
+│   └── tally.json
+├── output.md                   # winner case
+│  OR
+├── output-A.md                 # 1-1-1 tie case
+├── output-B.md
+├── output-C.md
+├── verdict.json                # v2 schema
+└── .done
+```
+
+### Nonce scope
+
+All LLM-sourced text wrapped with `[nonce-<hex>]` fences before being fed into downstream prompts:
+- R1 outputs → R2 peer aggregates
+- R2 outputs → ballot input (`rounds/2/aggregate.md`)
+
+Operator question is NOT fenced but IS sanity-scanned at load time for `^=== ` patterns.
+
+### Ballot contract
+
+```
+=== USER QUESTION ===
+<question>
+=== END USER QUESTION ===
+
+=== CANDIDATES ===
+=== EXPERT: A [nonce-...] ===
+<A's R2 output>
+=== END EXPERT: A [nonce-...] ===
+
+=== EXPERT: B [nonce-...] ===
+...
+=== END EXPERT: B [nonce-...] ===
+
+...
+
+=== END CANDIDATES ===
+
+Pick the label whose answer is best. Output ONLY the line: VOTE: <label>
+```
+
+Expert parses its own answer back: regex `(?m)^VOTE: ([A-Z])$`. Validates against active label set.
+
+## Post-Completion
+
+*Items requiring manual intervention or external systems — no checkboxes, informational only.*
+
+**Manual verification:**
+- Run `council "what is 2+2?"` from a plain shell (not inside an active `claude` session) and verify a real answer is returned via the debate+vote flow.
+- Run `council "Raft or Paxos?"` on a question likely to split the council; observe whether a tie arises (should be rare).
+- Verify `council resume` after killing a real run mid-R2 via SIGINT — expect the session to complete without data loss.
+- Inspect `verdict.json` structure and ensure downstream tools (if any) handle the v2 shape.
+
+**External system updates:**
+- After PR merge, update README install snippet if any Go version bumped.
+- Verify GitHub Actions / CI picks up v2 smoke tests.
+
+**Non-goals flagged for v3** (reference design §5):
+- Multi-vendor executors (Codex, Gemini)
+- Classifier / structured-output schemas
+- Judge polish step (if operational data shows raw text too rough)
+- Tiebreak mechanism for 1-1-1 (if operational data shows ties common)
+- Ranking / rating / numerical-estimation modes
+- Per-section SHA-256 injection boundaries


### PR DESCRIPTION
## Summary

v2 design + technical spec for the **simplified debate engine**. Single flow: blind R1 → peer-aware R2 → experts vote → winner's text returned verbatim (or all tied outputs on 1-1-1 tie).

**Not in v2** (removed in Round 5): classifier, per-type profile branching, judge/synthesis/polish step, tournament + self-defense, FACT:/SOURCE: factual path.

**In v2:**
- Debate rounds (blind R1, peer-aware R2) — ADR-0008
- Stable anonymization + per-session nonce injection boundary — ADR-0008
- Universal voting as the aggregation mechanism (no single judge, no single-model bias)
- `council resume` subcommand (D14) for interrupted sessions
- Carry-forward on R2 failure (quality-first tolerance)

## Design rationale

- **Classifier/flow-branching removed:** dialectic analysis showed the vote and factual paths' primary value was structured machine-readable output — not needed since v2 stays a human-readable-answer tool.
- **Judge removed:** a single judge creates a single point of model bias. Voting distributes the final decision across all N experts (design D15). Research support: Panickssery 2024, Zheng 2023, Du et al 2024 (voting variants).
- **Tiebreak (1-1-1) = surface all:** YAGNI per D16. If ties turn out common in practice, we'll add a tiebreak mechanism informed by real data.

## Files in this PR

- `docs/design/v2.md` — source-of-truth design (decisions D1–D3, D5–D8, D10–D12, D14–D16; §5 research map)
- `docs/plans/v2-debate-engine.md` — derivative technical spec (CLI, config, session layout, verdict.json v2 schema, 5-task impl plan)
- `docs/adr/0007-classifier-selects-per-type-profile.md` — **superseded** (retained for history)
- `docs/adr/0008-debate-rounds-anonymization-injection.md` — accepted (minor edit: N>26 footnote updated)
- `docs/adr/0009-tournament-self-defense.md` — **superseded** (retained for history)
- `docs/adr/0004-flat-config-mvp.md`, `docs/adr/0006-synthesis-only-judge.md` — updated to reflect Round 5 state
- `docs/architect-review.md` — Part C ADR summary + Part G (v2 analysis) updated

## Test plan

- [ ] Read `docs/design/v2.md` end-to-end; confirm single-flow diagram (§2.2), no classifier/judge/tournament references in current-state prose
- [ ] Read `docs/plans/v2-debate-engine.md` §7 orchestration + §8 anonymization + §15 fitness functions
- [ ] Confirm `docs/adr/0007` and `docs/adr/0009` bear superseded headers
- [ ] Confirm research map in §5 points the right citations to D8 / D15
- [ ] Scan for stale mentions of classifier/factual/tournament/judge in current-state prose

🤖 Generated with [Claude Code](https://claude.com/claude-code)