### PR TITLE
docs: v3 multi-CLI design + ADR-0012/0013 + ralphex plan

### DIFF
--- a/docs/adr/0005-single-cli-multiple-personas.md
+++ b/docs/adr/0005-single-cli-multiple-personas.md
@@ -1,6 +1,12 @@
 # ADR-0005: Single model/CLI at MVP; multiple expert personas
 
-**Status:** Proposed.
+**Status:** Superseded by ADR-0012 (2026-04-25).
+
+> v3 lifts the single-CLI constraint this ADR preserved through v1
+> and v2. See `docs/adr/0012-multi-cli-executors.md` for the
+> cross-vendor executor design. The text below is retained for
+> historical continuity and for the design rationale that still
+> applies to the N>=2 expert count invariant (unchanged by v3).
 
 ## Context
 

--- a/docs/adr/0005-single-cli-multiple-personas.md
+++ b/docs/adr/0005-single-cli-multiple-personas.md
@@ -3,10 +3,15 @@
 **Status:** Superseded by ADR-0012 (2026-04-25).
 
 > v3 lifts the single-CLI constraint this ADR preserved through v1
-> and v2. See `docs/adr/0012-multi-cli-executors.md` for the
-> cross-vendor executor design. The text below is retained for
-> historical continuity and for the design rationale that still
-> applies to the N>=2 expert count invariant (unchanged by v3).
+> and v2; it also relaxes validation to allow `len(experts) == 1`
+> (so `council init` can write a working profile when only one CLI
+> is authed on the host). See `docs/adr/0012-multi-cli-executors.md`
+> for the cross-vendor executor design and `docs/plans/2026-04-25-v3-multi-cli.md`
+> Task 7 for the validator change. The text below is retained for
+> historical continuity and for the original MVP rationale for
+> preferring N≥2 expert profiles — a preference v3 honors in its
+> default `council init` output (quorum = min(2, N)) even though
+> the validator no longer enforces N≥2 as a hard invariant.
 
 ## Context
 

--- a/docs/adr/0012-multi-cli-executors.md
+++ b/docs/adr/0012-multi-cli-executors.md
@@ -1,0 +1,307 @@
+
+# ADR-0012: Multi-CLI Executors (Codex + Gemini)
+
+**Status:** Proposed
+**Date:** 2026-04-24
+**Supersedes:** ADR-0005 (single-CLI-multiple-personas MVP constraint)
+**Depends on:** ADR-0010 (web tools for experts — the `AllowedTools` field
+flowing from `pkg/debate/rounds.go` is the integration point), ADR-0011
+(nonce every structural fence — no direct interaction but implementation
+lands on top of it)
+
+## Context
+
+ADR-0005 (v1 MVP) shipped with one CLI for per-CLI verification
+economy. It forecast `v2 adds executor: codex and executor: gemini-cli`.
+v2 shipped in PR #4 still claude-only; v2.md §1.4 retains the
+single-vendor caveat. This ADR executes the forecast.
+
+Zhang et al. 2025 ("Stop Overvaluing Multi-Agent Debate",
+arXiv:2502.08788) found MAD beats single-agent baselines *primarily*
+when model heterogeneity is present. v2's three Claude Sonnet experts
+are three samples of one distribution; R1 disagreement is correlated,
+R2 refinement is self-consensus-prone. Cross-vendor lineages (Anthropic
+/ OpenAI / Google) give independent training corpora, restoring the
+Condorcet independence the voting stage implicitly assumes.
+
+**Webfetch compatibility is a hard requirement.** PR #5 (ADR-0010 +
+ADR-0011) ships web tools hardcoded in `pkg/debate/rounds.go`:
+`AllowedTools = ["WebSearch", "WebFetch"]` on every expert spawn. For
+the cross-vendor debate to carry the web-augmented quality that PR #5
+delivers, codex and gemini experts must also fetch/search live — not
+just answer from priors. A priors-only codex/gemini would silently
+regress the web-tool quality gains PR #5 introduces, exactly on the
+cross-vendor peer signal the debate relies on.
+
+## Decision
+
+Add `pkg/executor/codex/` and `pkg/executor/gemini/`. Each implements
+the existing `Executor` interface; each registers via `init()`. Each
+translates the webfetch `AllowedTools` / `PermissionMode` fields to
+its native CLI surface so live web tools reach every expert.
+
+**Interface extension** — one new method:
+
+```go
+type Executor interface {
+    Name() string
+    BinaryName() string  // for exec.LookPath in council init + preflight
+    Execute(ctx context.Context, req Request) (Response, error)
+}
+```
+
+**Model naming (A2):** literal CLI model IDs in profile YAML;
+`MapModel` is identity for every executor. `Request.Model` doc:
+"literal CLI `--model` flag value, verbatim." Claude CLI aliases
+`sonnet`/`opus`/`haiku` server-side so profiles using those
+aliases work without translation.
+
+**Per-CLI AllowedTools translation:**
+
+| Canonical (webfetch constant) | claude-code | codex | gemini-cli |
+|---|---|---|---|
+| `WebSearch` | passed verbatim to `--allowedTools WebSearch,WebFetch` | triggers `-c tools.web_search=true` (once per call, regardless of whether fetch is also present) | triggers write of policy.toml allowing `google_web_search` + `web_fetch` and passes `--policy <tmpfile>` |
+| `WebFetch` | passed verbatim to `--allowedTools` | same single `web_search` tool (codex has no separate fetch — the hosted `web_search` tool covers "fetch this URL" semantics) | same — a single policy file handles both; no duplicated flags |
+
+**PermissionMode translation:**
+- claude-code: `--permission-mode <mode>` (v1 contract, unchanged).
+- codex: PermissionMode `bypassPermissions` → no separate flag needed;
+  codex's tool-call auto-approval is driven by `--sandbox read-only`
+  (already in our invocation) + `--ephemeral`. PermissionMode is
+  recorded in the executor for interface compat but does not change
+  argv.
+- gemini-cli: PermissionMode `bypassPermissions` → write the
+  embedded policy TOML to `$GEMINI_CLI_HOME/policy.toml` and append
+  `--policy $GEMINI_CLI_HOME/policy.toml` to argv. Empty
+  PermissionMode → no policy file written, no `--policy` flag;
+  gemini's default-deny on `web_fetch` in headless applies (which
+  is exactly what ballot subprocesses want). Chosen over `--yolo`
+  because `--yolo` emits a deprecation warning in gemini 0.38.2
+  and widens the allow-list to `*`.
+
+**Empty `AllowedTools` is the ballot path.** Webfetch hardcodes
+`AllowedTools: nil` on ballot spawns (ADR-0010 D17 + F17). Codex
+and gemini executors check the slice length: empty → no translation
+flags appended. This is mechanism, not backward-compat surface —
+there is one user (the author) and no v1/v2 profiles in flight.
+
+## Per-executor invocation specs
+
+### Codex
+
+```go
+argv := []string{
+    c.binary(), "exec",
+    "-m", req.Model,
+    "--sandbox", "read-only",
+    "--skip-git-repo-check",
+    "--ephemeral",
+    "--color", "never",
+    "-",  // stdin prompt
+}
+// Translation: any web tool in AllowedTools → enable web_search once.
+if containsWebTool(req.AllowedTools) {
+    argv = append(argv[:len(argv)-1],
+        "-c", "tools.web_search=true",
+        "-")
+}
+```
+
+- **MapModel:** identity.
+- **Env:** inherit `os.Environ()`. Codex reads auth from
+  `~/.codex/auth.json` or env (OpenAI API key).
+- **BinaryName:** `"codex"`.
+- **Rate-limit markers** (source: `codex-rs/protocol/src/error.rs`):
+  1. `you've hit your usage limit`
+  2. `quota exceeded. check your plan`
+  3. `selected model is at capacity`
+  4. `exceeded retry limit, last status: 429`
+  5. `upgrade to plus to continue`
+  6. fallback regex: `(?i)rate[_ ]?limit|insufficient_quota|usage_limit_reached`
+- **HelpCmd:** `codex /status`.
+
+### Gemini
+
+```go
+argv := []string{
+    g.binary(),
+    "-m", req.Model,
+    "-o", "text",
+    // stdin carries prompt (no -p)
+}
+// Translation: when PermissionMode == bypassPermissions (the
+// webfetch expert-path signal), write embedded policy TOML to
+// $GEMINI_CLI_HOME/policy.toml and pass --policy. Empty →
+// nothing added; gemini's default-deny on web_fetch in headless
+// applies (ballot invariant).
+if req.PermissionMode == "bypassPermissions" {
+    policyPath := filepath.Join(tmpHome, "policy.toml")
+    if err := os.WriteFile(policyPath, []byte(geminiPolicyTOML), 0o600); err != nil {
+        return executor.Response{}, fmt.Errorf("gemini: write policy: %w", err)
+    }
+    argv = append(argv, "--policy", policyPath)
+}
+```
+
+Embedded policy body (`//go:embed policy.toml` or as a string
+constant):
+
+```toml
+[[rule]]
+toolName = ["google_web_search", "web_fetch"]
+decision = "allow"
+priority = 100
+```
+
+- **MapModel:** identity.
+- **Env:** inherit (plus `GEMINI_CLI_HOME=<ephemeral tmp dir>` set
+  per-call by the executor for no-session-persistence parity). No
+  API-key env var — auth is OAuth against the user's Google
+  subscription (set up once via gemini's login flow; credentials
+  cached under `~/.gemini/`). Known upstream bug #22648: OAuth-
+  personal can infinite-loop on 429 — mitigated by our per-expert
+  timeout + runner SIGTERM/SIGKILL.
+- **BinaryName:** `"gemini"`.
+- **Rate-limit markers** (source:
+  `packages/core/src/utils/googleQuotaErrors.ts`):
+  1. `RESOURCE_EXHAUSTED`
+  2. `QUOTA_EXHAUSTED`
+  3. `RATE_LIMIT_EXCEEDED`
+  4. `exceeded your current quota`
+  5. `Please retry in`
+- **HelpCmd:** `check https://aistudio.google.com/apikey for quota and billing`.
+
+## Alternatives considered
+
+**a) One multi-CLI dispatch executor.** Rejected — couples every new
+CLI to a shared file; violates ADR-0005's extension model.
+
+**b) Hot-spare / fallback mode.** Rejected — goal is diversity *in*
+the debate, not resilience.
+
+**c) Opt-in multi-CLI profile, keep claude as default.** Rejected —
+the entire point is making cross-vendor the *default*; operators can
+still write single-CLI profiles.
+
+**d) Semantic tier aliases (`model: smart`).** Rejected — stale fast,
+meaning drifts per vendor; literal IDs keep model choice in YAML
+where it belongs.
+
+**e) L1 flag-based tool lockdown.** N/A after webfetch — webfetch's
+whole point is experts SHOULD use tools. Irrelevant alternative.
+
+**f) Ship priors-only codex/gemini in v3; translate in v4.**
+Rejected per user requirement: webfetch quality must hold across all
+three vendors in the v3 landing. Priors-only codex/gemini would
+regress the cross-vendor peer signal exactly on research-heavy
+questions.
+
+**g) Use `--yolo` for gemini (broad approval bypass).** Rejected —
+`--yolo` allows `*`, emits a stderr warning in 0.38.2, and is
+flagged for removal in 1.0. Wrong answer twice over.
+
+**h) Use `--allowed-tools google_web_search,web_fetch --yolo` for
+gemini.** Rejected — `--allowed-tools` and `--yolo` are both
+deprecated-with-removal-pending in 0.38.2. Emits deprecation
+warnings on every call. Policy Engine (`--policy <file>`) is the
+forward-compatible surface per
+`gemini.com/docs/core/policy-engine`.
+
+**h') Policy Engine via `--policy <file>`.** Chosen. Executor
+writes a 4-line TOML (`[[rule]] toolName=["google_web_search",
+"web_fetch"] decision="allow" priority=100`) to
+`$GEMINI_CLI_HOME/policy.toml` per call (the ephemeral home
+already exists for session-persistence). Passes `--policy <that
+path>` in argv. No deprecation warnings. No `--yolo`. Clean stdout.
+Smoke-verified 2026-04-25.
+
+**i) Dual-enable codex: `-c tools.web_search=true` AND attempt to
+enable a separate fetch tool.** Rejected — codex doesn't have a
+separate fetch. The hosted `web_search` tool's model can fetch URLs
+when prompted. The claude `WebFetch` call maps to the same codex
+`web_search` tool — no duplication, no missing functionality.
+
+## Research backing
+
+1. **Zhang et al. 2025** (arXiv:2502.08788) — MAD beats single-agent
+   baselines *primarily* under heterogeneity. Direct justification
+   for cross-vendor.
+2. **Liu et al. 2025 "Groupthink in LLM Ensembles"** (TO-VERIFY
+   citation) — same-family models show correlated errors; Condorcet
+   independence violated.
+3. **A-HMAD (Zhou & Chen 2025)** — role diversity helps; v3 does NOT
+   ship role-diversity (same prompts across experts), only vendor-
+   diversity.
+4. **Wan et al. 2025 "Talk Isn't Always Cheap"** (arXiv:2509.05396)
+   — sycophancy in homogeneous debate. Cross-vendor peers reduce it.
+
+Honest gap: no published head-to-head compares three-vendor debate
+with matched prompts against three-persona-single-vendor debate. We
+infer from aggregate findings.
+
+## Risks
+
+**R-v3-01: Per-CLI auth friction.** Mitigation: `council init` live-
+probe fails fast per CLI with actionable message.
+
+**R-v3-02: Headless gotchas differ.** Mitigation: invocation specs
+codify working flags; live tests catch regressions.
+
+**R-v3-03: Tool-surface per vendor requires empirical verification
+on every CLI release.** Codex's `-c tools.web_search=true` and
+gemini's `--policy <file>` are current-gen (smoke-verified
+2026-04-25 against codex-cli 0.124.0 + gemini-cli 0.38.2). Either
+may shift. Mitigation: translation code lives in one place per
+executor; a CLI update that breaks it is a one-line PR to that
+executor (plus the live smoke failing to flag it).
+
+**R-v3-04: Rate-limit pattern drift.** Mitigation: marker lists
+additive + case-insensitive + regex fallback.
+
+**R-v3-05: Cold-start latency on Node-based CLIs.** Webfetch already
+bumps timeout to 300s; comfortable margin.
+
+**R-v3-06: Model-ID rotation.** Mitigation: literal IDs; YAML edit,
+not code change; `council init --force` regenerates.
+
+**R-v3-07: Single-vendor outage during `council init`.** Mitigation:
+logged verdict + skip; `--force` re-runs after recovery.
+
+**R-v3-08: Gemini Policy Engine TOML schema drift.** The
+`[[rule]] toolName=... decision="allow" priority=N` shape is
+current-gen. Gemini-cli's `docs/core/policy-engine` indicates the
+schema is stable enough to be the replacement for deprecated
+`--allowed-tools`, but it may evolve before 1.0 GA. Mitigation:
+policy body is 4 lines embedded in the executor; a schema change
+is a one-line edit to that string.
+
+**R-v3-09: Codex's hosted `web_search` tool pricing / availability.**
+OpenAI may change availability of the hosted tool, gate it by tier,
+or change pricing. Mitigation: if the flag is set but the tool is
+unavailable for the account, codex either errors or silently ignores
+— the live verification plan detects this.
+
+## Fitness functions
+
+Append to v2.md §8:
+
+| # | Fitness | Concrete check |
+|---|---|---|
+| F18 | Codex executor registers | Side-effect import → `executor.Get("codex")` succeeds |
+| F19 | Gemini executor registers | Side-effect import → `executor.Get("gemini-cli")` succeeds |
+| F20 | BinaryName() returns expected | claude-code→"claude"; codex→"codex"; gemini-cli→"gemini" |
+| F21 | Preflight rejects missing binary | Profile referencing missing binary → preflight error names binary + profile line |
+| F22 | `council init` idempotent | Two runs without `--force` → second exits 0 without overwriting |
+| F23 | `council init --force` regenerates | Second run with `--force` overwrites |
+| F24 | Live-probe gate | Mock CLI failing probe excluded from generated profile |
+| F25 | Literal model IDs pass through | `model: gpt-5.5` → `codex exec -m gpt-5.5 ...` (identity MapModel) |
+| F26 | Codex enables web_search when AllowedTools contains web | `AllowedTools=["WebSearch"]` → argv contains `-c tools.web_search=true`. `AllowedTools=nil` → NO such flag |
+| F27 | Gemini writes policy + emits --policy when PermissionMode is bypassPermissions | `PermissionMode="bypassPermissions"` → `$GEMINI_CLI_HOME/policy.toml` exists with the allow-rule body; argv contains `--policy <that path>`. Empty PermissionMode → NO policy file, NO `--policy` flag; argv does NOT contain `--allowed-tools` or `--yolo` (both deprecated) |
+| F28 | Claude routing unchanged | Existing webfetch F13/F14 still pass for claudecode executor |
+| F29 | Live codex smoke — fetches a URL | `COUNCIL_LIVE_CODEX=1` gated test: prompt "cite current Go version with URL", assert stdout contains `https://` |
+| F30 | Live gemini smoke — fetches a URL | `COUNCIL_LIVE_GEMINI=1` gated test: same question, assert stdout contains `https://` |
+
+## Status
+
+Proposed. Paired with ADR-0013.
+

--- a/docs/adr/0012-multi-cli-executors.md
+++ b/docs/adr/0012-multi-cli-executors.md
@@ -111,13 +111,14 @@ if containsWebTool(req.AllowedTools) {
 - **Env:** inherit `os.Environ()`. Codex reads auth from
   `~/.codex/auth.json` or env (OpenAI API key).
 - **BinaryName:** `"codex"`.
-- **Rate-limit markers** (source: `codex-rs/protocol/src/error.rs`):
+- **Rate-limit markers** (source: `codex-rs/protocol/src/error.rs`;
+  substring match only — no regex fallback per strict-YAGNI; a
+  future un-matched 429 is a one-line PR to extend this list):
   1. `you've hit your usage limit`
   2. `quota exceeded. check your plan`
   3. `selected model is at capacity`
   4. `exceeded retry limit, last status: 429`
   5. `upgrade to plus to continue`
-  6. fallback regex: `(?i)rate[_ ]?limit|insufficient_quota|usage_limit_reached`
 - **HelpCmd:** `codex /status`.
 
 ### Gemini

--- a/docs/adr/0013-no-runner-ratelimit-retries.md
+++ b/docs/adr/0013-no-runner-ratelimit-retries.md
@@ -3,7 +3,7 @@
 
 **Status:** Proposed
 **Date:** 2026-04-24
-**Amends:** v1.md §10 (retry-ownership split)
+**Amends:** `docs/design/v1.md` §10 (retry-ownership split)
 **Depends on:** ADR-0012
 
 ## Context

--- a/docs/adr/0013-no-runner-ratelimit-retries.md
+++ b/docs/adr/0013-no-runner-ratelimit-retries.md
@@ -1,0 +1,146 @@
+
+# ADR-0013: No Runner-Side Rate-Limit Retries
+
+**Status:** Proposed
+**Date:** 2026-04-24
+**Amends:** v1.md §10 (retry-ownership split)
+**Depends on:** ADR-0012
+
+## Context
+
+v1/v2 `pkg/runner.Run()` retries on 429 up to `RateLimitMaxRetries`
+times + classifies stderr into `ErrRateLimit`. Single-CLI council
+made this correct — a rate-limited call blocked the whole session;
+silent retry let runs succeed.
+
+v3 (ADR-0012) runs each expert on a different vendor. Independent
+rate-limit buckets per vendor mean one-vendor rate-limit rarely
+correlates with the others being limited. Orchestrator-level quorum
+is the right abstraction to absorb single-vendor outage.
+
+Runner-side retry now actively harms:
+
+1. Wastes wall-clock on retries against the one failing vendor
+   instead of returning a verdict from survivors.
+2. Doubles up inside the CLI — both codex and gemini already retry
+   429 internally (codex `RetryOn::retry_429`; gemini
+   `retryWithBackoff` in `retry.ts`). Stacking another layer just
+   repeats the same failing subprocess.
+3. Hides partial-failure diagnostics. Rate-limit is an operationally
+   interesting signal (credit out, quota hit); silent retry swallows
+   it. Ralphex surfaces typed errors + per-CLI help (see
+   `umputun/ralphex` `pkg/processor/runner.go:1191-1207`).
+
+## Decision
+
+Remove the rate-limit retry loop from `pkg/runner`. Remove
+classification too — executors own detection via
+`runner.DetectLimit(stderrPath, patterns)`.
+
+**New type** (`pkg/runner/limiterror.go`):
+
+```go
+type LimitError struct {
+    Pattern string  // matched substring
+    Tool    string  // executor name, e.g. "codex"
+    HelpCmd string  // e.g. "codex /status"
+}
+func (e *LimitError) Error() string {
+    return fmt.Sprintf("rate limit hit on %s: matched %q — %s",
+        e.Tool, e.Pattern, e.HelpCmd)
+}
+```
+
+**`RunRequest` change:**
+
+```go
+// REMOVED: RateLimitMaxRetries int
+// Detection/classification is executor-owned now.
+```
+
+**New helper:**
+
+```go
+func DetectLimit(stderrPath string, patterns []string) (matched string, ok bool)
+```
+
+Case-insensitive substring scan; returns first match.
+
+**Executor pattern:**
+
+```go
+resp, err := runner.Run(ctx, req)
+if err != nil {
+    if matched, ok := runner.DetectLimit(req.StderrFile, myPatterns); ok {
+        return executor.Response{Duration: resp.Duration},
+            &runner.LimitError{Pattern: matched, Tool: c.Name(),
+                HelpCmd: c.helpCmd()}
+    }
+}
+```
+
+**Runner stays oblivious.** `runner.Run` no longer scans stderr for
+429; returns `ErrNonZeroExit`; executors classify further.
+`ratelimit.go`'s `scanStderr` is removed; `DetectLimit` replaces it.
+
+**Orchestrator on `*LimitError`:**
+
+- Treated as failed survivor for quorum (same path as timeout /
+  non-zero exit).
+- Collected into per-round `rateLimits []*LimitError`.
+- Serialized into `verdict.json` as optional top-level `rate_limits`
+  array: `[{"executor":"codex","pattern":"...","help_cmd":"codex /status",
+  "round":1,"expert":"codex_expert"}]`. Additive; no schema bump.
+- If `survivors < quorum && len(rateLimits) > 0`, `debate.Run*`
+  returns `ErrRateLimitQuorumFail`.
+
+**`cmd/council` on `ErrRateLimitQuorumFail`:**
+
+- Exit code 6 (`ExitRateLimitQuorumFail`). Distinct from 2 (generic
+  quorum fail).
+- Print per-CLI help footer, one line per affected CLI:
+  ```
+  error: rate limit hit on codex — run 'codex /status' for more information
+  error: rate limit hit on gemini-cli — check https://aistudio.google.com/apikey
+  error: quorum failed (1/2 experts surviving, 2 rate-limited)
+  ```
+- verdict.json still written (status `quorum_failed` + `rate_limits`).
+
+## Alternatives considered
+
+**a) Keep retry with lower budget.** Rejected — the number isn't the
+problem; the duplication is.
+
+**b) Exit council run on any 429.** Rejected — discards 2-of-3
+survivor work that ADR-0012's whole design is meant to preserve.
+
+**c) Session-level retry (re-run the whole session after delay).**
+Deferred to v4.
+
+**d) Backwards-compat retry flag.** N/A — single-user project,
+no in-flight v2 callers; behavior shift just lands.
+
+## Consequences
+
+- `pkg/runner.Run` shrinks.
+- Rate-limit markers + HelpCmd live next to per-CLI invocation
+  specs — cohesive.
+- `verdict.json` gains additive field; no schema bump.
+- New exit code 6.
+- Quorum absorbs single-vendor rate-limit (the whole point of
+  ADR-0012); two-vendor rate-limit fails the run with exit 6.
+
+## Fitness functions
+
+| # | Fitness | Check |
+|---|---|---|
+| F31 | No retry on first rate-limit hit | Stub CLI emits marker on first attempt → executor returns `*LimitError` with no delay |
+| F32 | LimitError fields populated | Tool + Pattern + HelpCmd non-empty per-CLI |
+| F33 | Quorum absorbs single rate-limit | 3-expert profile, one mocked → `*LimitError`; quorum=2; verdict succeeds; `rate_limits` populated |
+| F34 | Quorum fails on ≥2 rate-limits → exit 6 | 3-expert, two rate-limited → exit 6; stderr shows two help footers |
+| F35 | verdict.json.rate_limits shape | Rate-limited expert produces expected entry |
+
+## Status
+
+Proposed. Paired with ADR-0012.
+

--- a/docs/design/v2.md
+++ b/docs/design/v2.md
@@ -36,8 +36,11 @@ N parallel monologues").
 ### 1.4 What v2 is NOT
 
 - Not a performance tool — debate is 3–5× more expensive than v1.
-- Not a multi-vendor framework — v2 still runs on Claude Code only;
-  architecture is ready for Codex/Gemini in v3.
+- ~~Not a multi-vendor framework — v2 still runs on Claude Code only;
+  architecture is ready for Codex/Gemini in v3.~~ *Superseded by
+  ADR-0012 (v3 landed): default profile now runs claude-code +
+  codex + gemini-cli. See `docs/design/v3-multi-cli.md` and
+  `docs/adr/0012-multi-cli-executors.md`.*
 - Not a benchmark runner — no built-in evaluation harness.
 - Not a self-repair system — v2 does not autonomously recover or revise
   failed runs, but operators can explicitly continue interrupted work
@@ -1181,6 +1184,7 @@ remain in the respective ADR files for historical record:
 | 0 | success (clear winner, winner's R2 text returned) | v1 |
 | 1 | config/input error, `injection_suspected_in_question` | v1 (extended) |
 | 2 | quorum_failed, `quorum_failed_round_N`, **`no_consensus` (1-1-1 tie)** | v1 (extended) |
+| 6 | `rate_limit_quorum_failed` — quorum unmet because ≥1 vendor was rate-limited; per-CLI help footer printed (see ADR-0013) | v3 |
 | 130 | SIGINT / interrupted | v1 |
 
 Notes:

--- a/docs/design/v2.md
+++ b/docs/design/v2.md
@@ -37,9 +37,10 @@ N parallel monologues").
 
 - Not a performance tool — debate is 3–5× more expensive than v1.
 - ~~Not a multi-vendor framework — v2 still runs on Claude Code only;
-  architecture is ready for Codex/Gemini in v3.~~ *Superseded by
-  ADR-0012 (v3 landed): default profile now runs claude-code +
-  codex + gemini-cli. See `docs/design/v3-multi-cli.md` and
+  architecture is ready for Codex/Gemini in v3.~~ *Superseded by the
+  v3 multi-vendor plan recorded in ADR-0012 (Proposed): the default
+  profile is intended to run claude-code + codex + gemini-cli once
+  v3 implementation lands. See `docs/design/v3-multi-cli.md` and
   `docs/adr/0012-multi-cli-executors.md`.*
 - Not a benchmark runner — no built-in evaluation harness.
 - Not a self-repair system — v2 does not autonomously recover or revise
@@ -1177,7 +1178,10 @@ remain in the respective ADR files for historical record:
   retry/carry machinery handles the operational impact; surfaced via
   stderr on failure.
 
-### 7.3 Exit Codes (v2)
+### 7.3 Exit Codes
+
+v2 exit codes, plus v3-introduced code 6 (forward reference; not
+emitted by v2 binaries — see ADR-0013 for v3 semantics).
 
 | Code | Meaning | Introduced |
 |---|---|---|

--- a/docs/design/v3-multi-cli.md
+++ b/docs/design/v3-multi-cli.md
@@ -1,0 +1,183 @@
+
+# council v3 — Multi-CLI Supplement
+
+> Layers on v2.md (as amended by ADR-0010/0011/v2-web-tools.md).
+> Authoritative decisions in ADR-0012 + ADR-0013.
+
+## 1. What changes in v3
+
+### 1.1 Executor surface
+
+`pkg/executor/codex/` and `pkg/executor/gemini/`, mirroring
+claudecode's structure. `Executor` gains `BinaryName() string`.
+
+Every executor translates webfetch's `AllowedTools` /
+`PermissionMode` to its native flag surface. Claude unchanged;
+codex adds `-c tools.web_search=true` when web tools requested;
+gemini writes a Policy Engine TOML to its per-call ephemeral
+`GEMINI_CLI_HOME` and passes `--policy <file>` (forward-compatible
+replacement for deprecated `--allowed-tools`/`--yolo`).
+
+### 1.2 Default profile (written by `council init`)
+
+Embedded `defaults/default.yaml` stays claude-only (safe fallback on
+fresh install with only `claude` on PATH). `council init` writes
+per-host `~/.config/council/default.yaml`. Generated when all three
+CLIs verify:
+
+```yaml
+version: 2
+name: default
+experts:
+  - name: claude_expert
+    executor: claude-code
+    model: opus
+    prompt_file: prompts/independent.md
+    timeout: 300s
+  - name: codex_expert
+    executor: codex
+    model: gpt-5.5
+    prompt_file: prompts/independent.md
+    timeout: 300s
+  - name: gemini_expert
+    executor: gemini-cli
+    model: gemini-3.1-pro-preview
+    prompt_file: prompts/independent.md
+    timeout: 300s
+quorum: 2
+max_retries: 1
+rounds: 2
+round_2_prompt_file: prompts/peer-aware.md
+voting:
+  ballot_prompt_file: prompts/ballot.md
+  timeout: 300s
+```
+
+- `timeout: 300s` matches webfetch default (tool latency).
+- `quorum: 2` — cross-vendor diversity makes one-vendor outage
+  common; two-vendor outage rare.
+- Subset profiles: `quorum = min(2, len(experts))`.
+
+### 1.3 `council init`
+
+```
+council init [--force]
+```
+
+1. Idempotent — refuses existing file without `--force`.
+2. Detect — `exec.LookPath(executor.BinaryName())` per registered
+   executor.
+3. Probe — 30s live prompt "respond with OK"; stdout must contain
+   "OK".
+4. Fail-open — zero verified → non-zero exit.
+5. Write — profile per verified set; `quorum = min(2, len)`.
+6. Summary printed to stdout.
+
+### 1.4 Preflight
+
+Every run. `exec.LookPath` per expert's `BinaryName()`. Miss → exit
+with clear message. No live probe (too slow per-run).
+
+### 1.5 Rate-limit surface (ADR-0013)
+
+- Runner no longer retries 429.
+- `*LimitError{Tool, Pattern, HelpCmd}` surfaces immediately.
+- Orchestrator absorbs via quorum.
+- verdict.json gains `rate_limits[]` additive field.
+- Exit code 6 on quorum fail due to rate-limits.
+
+## 2. Walkthrough
+
+§3.2 Anonymization — unchanged (label assignment independent of
+executor).
+§3.3 R1 — each expert's subprocess receives same prompt; different
+vendor; different model. Tool-surface hardcoded in `rounds.go`
+reaches all three executors; each translates to native flags per
+ADR-0012.
+§3.4 Peer aggregate — unchanged.
+§3.5 R2 — cross-vendor peers mean real refinement signal.
+§3.6 Ballot — unchanged; tools-off per webfetch.
+§3.7 Verdict — `rate_limits` field when any expert rate-limited.
+
+## 3. Per-executor notes
+
+### 3.1 Claude-code (unchanged from webfetch)
+
+`--allowedTools WebSearch,WebFetch --permission-mode bypassPermissions
+--no-session-persistence` when AllowedTools non-empty (empty →
+none of those flags). Rate-limit markers moved from runner to this
+executor (see ADR-0013). Markers: `you've hit your limit`,
+`usage limit exceeded`, `anthropic rate limit`. HelpCmd:
+`claude /usage`.
+
+### 3.2 Codex
+
+argv assembly:
+```
+codex exec -m <model> --sandbox read-only --skip-git-repo-check \
+  --ephemeral --color never -c tools.web_search=true -
+```
+(the `-c tools.web_search=true` is emitted when AllowedTools is
+non-empty; claude's `["WebSearch","WebFetch"]` both trigger the
+single codex `web_search` tool.)
+
+Rate-limit markers + HelpCmd per ADR-0012.
+
+### 3.3 Gemini
+
+argv assembly (PermissionMode == bypassPermissions):
+```
+gemini -m <model> -o text --policy $GEMINI_CLI_HOME/policy.toml
+```
+(stdin-piped prompt; no `-p`.)
+
+Executor writes a 4-line policy TOML at `$GEMINI_CLI_HOME/policy.toml`
+before invoking gemini. Policy body (embedded in the executor):
+
+```toml
+[[rule]]
+toolName = ["google_web_search", "web_fetch"]
+decision = "allow"
+priority = 100
+```
+
+No `--yolo`, no `--allowed-tools` — both deprecated in gemini
+0.38.2, slated for removal in 1.0. The Policy Engine surface is
+the supported forward-compatible path.
+
+### 3.4 Ballots still tools-off
+
+Webfetch Task 2 hardcodes `AllowedTools: nil, PermissionMode: ""`
+on ballot spawns. Codex and gemini executors see the empty values
+and emit no translation — no `-c tools.web_search=true`, no policy
+file written, no `--policy`. Ballot subprocesses stay priors-only
+across all three vendors. Consistent with webfetch's intent.
+
+## 4. Injection surface
+
+Unchanged — codex/gemini outputs flow through same nonce-fencing +
+forgery-scan path. Per-vendor stylistic differences contained
+within `output.md`.
+
+## 5. Token cost
+
+Webfetch estimates 8–15× claude single-pass under tool use. Multi-
+cli runs three experts in parallel (each using tools), so wall-clock
+stays similar; total token bill *spreads* across three vendor
+accounts (3× headroom before any single-vendor cap).
+
+## 6. What operators should know
+
+- Run `council init` after install; re-run with `--force` after
+  adding/removing CLIs.
+- Each CLI needs its own subscription-based auth, set up once:
+  `claude /login` (Anthropic); `codex login` (OpenAI); gemini's
+  OAuth flow (Google). All three cache credentials under
+  `~/.claude/` / `~/.codex/` / `~/.gemini/` respectively. No API
+  keys — the tooling is subscription-based, not pay-per-token.
+- Exit code 6 = rate-limit quorum failure (distinct from 2).
+- Model IDs are literal.
+- All three vendors now use live web tools; question quality in
+  cross-vendor debate does NOT regress from webfetch's claude-only
+  quality.
+

--- a/docs/plans/2026-04-25-v3-multi-cli.md
+++ b/docs/plans/2026-04-25-v3-multi-cli.md
@@ -1,0 +1,290 @@
+# v3 Multi-CLI Experts — Implementation Plan
+
+## Overview
+
+Implement ADR-0012 (multi-CLI executors — codex + gemini-cli) and ADR-0013 (no runner-side rate-limit retries) on top of the merged webfetch changes. Net delta: v2 debate engine's three experts now run on three different vendors (Anthropic / OpenAI / Google), each translating webfetch's hardcoded `AllowedTools = ["WebSearch", "WebFetch"]` + `PermissionMode = "bypassPermissions"` into its CLI's native tool-enablement surface. Rate-limit failures on any single CLI are absorbed by quorum instead of retried; if quorum fails because of rate-limits, new exit code 6 with per-CLI help footer.
+
+**Source of truth:** `/Users/ninja/council/multi-cli.md` (approved design package, 2026-04-25). Authoritative ADRs + supplement to be extracted into `docs/adr/0012-*.md`, `docs/adr/0013-*.md`, `docs/design/v3-multi-cli.md` as part of Task 9.
+
+**Hard prerequisite:** webfetch implementation (`docs/plans/2026-04-24-v2-web-tools.md`) MUST land on main before Task 1 of this plan. Multi-cli inherits `Request.AllowedTools` + `Request.PermissionMode` fields, ballot `AllowedTools: nil` invariant, 300s shipped timeout, updated prompts (`independent.md` / `peer-aware.md`), and ADR-0011's nonce-every-fence regex tightening. Starting this plan before webfetch lands produces uncompilable intermediate state.
+
+## Context (from discovery)
+
+**Smoke-verified 2026-04-25** on live CLIs (proves translation contracts before code is written):
+
+- codex-cli 0.124.0: `echo "..." | codex exec -c 'tools.web_search=true' --skip-git-repo-check -s read-only --color never --ephemeral -m gpt-5.5 -` → URL-cited answer, clean stdout.
+- gemini-cli 0.38.2: `echo "..." | gemini -m gemini-3.1-pro-preview -o text --policy <policy.toml>` with `[[rule]] toolName=["google_web_search","web_fetch"] decision="allow" priority=100` → URL-cited answer, no deprecation warnings.
+
+**Files touched by this plan:**
+- **New:** `pkg/executor/codex/{codex.go,codex_test.go,codex_live_test.go}`; `pkg/executor/gemini/{gemini.go,gemini_test.go,gemini_live_test.go}`; `cmd/council/{init.go,init_test.go,preflight.go,preflight_test.go}`; `docs/adr/0012-multi-cli-executors.md`; `docs/adr/0013-no-runner-ratelimit-retries.md`; `docs/design/v3-multi-cli.md`; `test/smoke/F14_live_multi_cli.sh`.
+- **Modified:** `pkg/executor/executor.go` (add `BinaryName() string`); `pkg/executor/claudecode/claudecode.go` (add `--no-session-persistence`, own rate-limit markers, wrap to `*LimitError`, implement `BinaryName`); `pkg/executor/mock/mock.go` (implement `BinaryName`); `pkg/runner/runner.go` (remove rate-limit retry branch; drop `RateLimitMaxRetries` field + `ErrRateLimit` sentinel; add `DetectLimit` helper; add `LimitError` type); `pkg/runner/ratelimit.go` (replace `scanStderr` internals with `DetectLimit` public helper); `pkg/runner/{runner_test.go,ratelimit_test.go}` (remove retry-behavior assertions; add `DetectLimit` table tests); `pkg/debate/{rounds.go,vote.go}` (classify via `errors.As`; collect `[]*LimitError`; `ErrRateLimitQuorumFail` sentinel); `pkg/session/verdict.go` (add `rate_limits[]`); `cmd/council/main.go` (wire init + preflight; `ExitRateLimitQuorumFail=6`; per-CLI footer); `cmd/council/executors_release.go` (add side-effect imports); `defaults/default.yaml` (embedded fallback unchanged — stays claude-only); `docs/design/v2.md` (§1.4, §4 D22–D24, §5, §6.3, §8, §9); `docs/adr/0005-single-cli-multiple-personas.md` (superseded annotation); `README.md`.
+
+**Key contracts to preserve:**
+- `Executor` interface extension is additive (`BinaryName() string`) — no break for existing claude-code, mock.
+- Post-webfetch `Request` shape (AllowedTools + PermissionMode) flows unchanged through codex/gemini executors; they translate, not redefine.
+- Ballot tools-off invariant (`AllowedTools: nil, PermissionMode: ""`) held across all three vendors without per-CLI conditionals (empty fields → no translation flags emitted).
+- Folder-as-database (ADR-0003) + atomic verdict.json write unchanged; `rate_limits[]` additive, no schema version bump.
+- Shipped `defaults/default.yaml` stays claude-only as safe fallback; per-host `~/.config/council/default.yaml` written by `council init` holds the three-CLI profile.
+
+**Models in generated init profile:**
+- claude: `opus`
+- codex: `gpt-5.5`
+- gemini: `gemini-3.1-pro-preview`
+
+## Development Approach
+
+- **Testing approach: TDD** — tests first, see them fail, implement, see them pass.
+- Complete each task fully before moving to the next.
+- **CRITICAL: every task MUST include new/updated tests** for code changes in that task.
+- **CRITICAL: all tests must pass before starting next task** — no exceptions.
+- **CRITICAL: update this plan file when scope changes during implementation.**
+- Single-user project — no backward-compat shims, no migration stories, no "v1 caller preserves" framings.
+
+## Testing Strategy
+
+- **Unit tests:** required every task. `go test ./...` must pass.
+- **Mock executor:** webfetch's `pkg/executor/mock/mock.go` already records AllowedTools/PermissionMode; extend to record argv for codex/gemini argv-translation fitness (F26/F27). `COUNCIL_MOCK_CALL_LOG` JSON-lines mechanism (v2-web-tools.md §7) used for smoke-binary assertions.
+- **Live CLI tests:** three `//go:build live`-gated files:
+  - `pkg/executor/codex/codex_live_test.go` gated by `COUNCIL_LIVE_CODEX=1`
+  - `pkg/executor/gemini/gemini_live_test.go` gated by `COUNCIL_LIVE_GEMINI=1`
+  - `test/smoke/F14_live_multi_cli.sh` gated by `COUNCIL_LIVE_ALL=1` (end-to-end three-CLI debate)
+- **Rate-limit quorum absorb / fail-exit tests** are unit-level only (mock executor returning `*LimitError`). Forcing live rate-limits on subscription-based APIs is impractical.
+- **Coverage target:** 80%+ per package.
+
+## Progress Tracking
+
+- Mark completed items with `[x]` immediately when done.
+- Add newly discovered tasks with ➕ prefix.
+- Document issues/blockers with ⚠️ prefix.
+- Update plan if implementation deviates from original scope.
+
+## What Goes Where
+
+- **Implementation Steps** (`[ ]` checkboxes): code + tests + doc updates inside this repo.
+- **Post-Completion** (no checkboxes): live smokes, PR review, benchmark runs.
+
+## Implementation Steps
+
+### Task 1: pkg/executor — interface extension
+
+- [ ] write test: claudecode's `BinaryName()` returns `"claude"`; mock's `BinaryName()` returns `"claude"` (the mock's `Name()` is already `"claude-code"` per `pkg/executor/mock/mock.go:84` so preflight `exec.LookPath` against the testbinary mock continues to resolve real `claude` when present on PATH)
+- [ ] add `BinaryName() string` to `Executor` interface in `pkg/executor/executor.go`
+- [ ] implement `BinaryName()` on `pkg/executor/claudecode/claudecode.go` → `"claude"`
+- [ ] implement `BinaryName()` on `pkg/executor/mock/mock.go` → `"claude"` (NOT `"mock"` — mock.Name() is `"claude-code"` so BinaryName must match real claude binary to keep smoke-binary preflight green under `-tags testbinary`)
+- [ ] update `Request.Model` docstring: "literal CLI `--model` flag value, verbatim. Each executor's MapModel is identity by default."
+- [ ] update `pkg/executor/executor.go` package doc: note webfetch's AllowedTools/PermissionMode fields are translated to native flags per executor
+- [ ] run `go test ./pkg/executor/...` — must pass before Task 2
+
+### Task 2: pkg/runner — remove retry loop, add LimitError + DetectLimit (also cleans up pkg/debate/rounds.go cascading ref)
+
+- [ ] write test: `runner.Run` returns `ErrNonZeroExit` immediately on first non-zero exit, no delay, no retry (even when stderr contains a 429-marker phrase)
+- [ ] write test: `runner.DetectLimit(stderrPath, patterns)` returns first-match + `true` on match; `""` + `false` on no-match; case-insensitive
+- [ ] write test: `LimitError.Error()` formats as `rate limit hit on <tool>: matched "<pattern>" — <helpcmd>`
+- [ ] delete rate-limit retry branch in `pkg/runner/runner.go` `Run()` function (`runner.go:124-142`)
+- [ ] remove `RateLimitMaxRetries` field from `RunRequest`
+- [ ] remove `ErrRateLimit` sentinel (`runner.go:97`)
+- [ ] **remove `RunResponse.RateLimited` field (`runner.go:82`)** — dies with the retry branch; existing code writes it only via the deleted path
+- [ ] remove `scanStderr` internals from `pkg/runner/ratelimit.go`
+- [ ] add exported `DetectLimit(stderrPath string, patterns []string) (string, bool)` helper (case-insensitive substring scan; reads file; first-match wins)
+- [ ] add `LimitError{Pattern, Tool, HelpCmd string}` type with `Error()` method
+- [ ] update `pkg/runner/runner_test.go`: remove `TestRunRetriesOnRateLimit*` + `TestRunRespectsRateLimitRetryBudget*`; drop `resp.RateLimited` assertions at lines 40, 178, 246-250, 278-279; drop `errors.Is(err, ErrRateLimit)` at lines 246, 278
+- [ ] update `pkg/runner/ratelimit_test.go`: rewrite for `DetectLimit` table-driven tests (case-insensitivity, first-match-wins, missing-file error surface)
+- [ ] **update `pkg/debate/rounds.go:578` — remove `errors.Is(err, runner.ErrRateLimit)` branch in `runWithFailRetry`.** The surviving code path treats rate-limit as a regular fail-retry-exhausting error; executors will wrap into `*LimitError` at their layer (not runner's). Compile-breaks without this; test `TestRunWithFailRetry*` in `rounds_test.go` must also drop the ErrRateLimit assertions.
+- [ ] update `pkg/executor/claudecode/claudecode.go`: stop passing `RateLimitMaxRetries`; own claude rate-limit marker list (`you've hit your limit`, `usage limit exceeded`, `anthropic rate limit`); call `runner.DetectLimit` after `runner.Run` errors; wrap into `*LimitError{Tool: "claude-code", HelpCmd: "claude /usage"}` on match
+- [ ] run `go test ./pkg/runner/... ./pkg/executor/... ./pkg/debate/...` — must pass before Task 3
+
+### Task 3: pkg/executor/claudecode — add --no-session-persistence
+
+- [ ] write test: claudecode executor argv contains `--no-session-persistence` on every call (tools-enabled and ballot path)
+- [ ] update `pkg/executor/claudecode/claudecode.go` argv assembly: append `--no-session-persistence` alongside webfetch's `--allowedTools` / `--permission-mode`
+- [ ] update argv-assembly table tests to assert the new flag
+- [ ] run `go test ./pkg/executor/claudecode/...` — must pass before Task 4
+
+### Task 4: pkg/executor/codex — new executor
+
+- [ ] write unit test: empty-Model → error
+- [ ] write unit test: happy path with `AllowedTools: nil` → argv = `codex exec -m <model> --sandbox read-only --skip-git-repo-check --ephemeral --color never -` (no `-c tools.web_search=true`)
+- [ ] write unit test: `AllowedTools: ["WebSearch", "WebFetch"]` → argv contains two consecutive entries `argv[i] == "-c" && argv[i+1] == "tools.web_search=true"` (exact two-token form, NOT concatenated `-c=tools.web_search=true`)
+- [ ] write unit test: `AllowedTools: ["WebSearch"]` alone → same `-c tools.web_search=true` (web_search covers fetch semantics; single trigger regardless of which web-tool names appear)
+- [ ] write unit test: timeout → runner timeout propagated
+- [ ] write unit test: non-zero exit with no rate-limit marker → returns error preserving exit code; NOT `*LimitError`
+- [ ] write unit test: each of 5 codex rate-limit markers → `*LimitError{Tool:"codex", Pattern:<matched>, HelpCmd:"codex /status"}` — one test case per marker (table-driven, one subtest per marker)
+- [ ] write `codex_live_test.go` gated by `//go:build live` + `COUNCIL_LIVE_CODEX=1`: sends "respond with the word OK"; asserts stdout contains `OK` (case-insensitive)
+- [ ] implement `pkg/executor/codex/codex.go`:
+  - `type Codex struct { Binary string }`
+  - `init() { executor.Register(&Codex{}) }`
+  - `Name() → "codex"`, `BinaryName() → "codex"` (or c.Binary if set), `MapModel → identity`
+  - `Execute`: argv per smoke-verified spec; runner.Run with MaxRetries:0; on error, call runner.DetectLimit with codex marker list; wrap into `*LimitError` on match
+- [ ] codex marker list as package-level `var codexLimitPatterns = []string{...}` — 5 explicit substrings only (no regex fallback; add one-line PR if an un-matched 429 is empirically observed, per strict-YAGNI policy)
+- [ ] run `go test ./pkg/executor/codex/...` — must pass before Task 5
+
+### Task 5: pkg/executor/gemini — new executor
+
+- [ ] write unit test: empty-Model → error
+- [ ] write unit test: stub binary script snapshots `$GEMINI_CLI_HOME/policy.toml` to `$COUNCIL_TEST_POLICY_SNAPSHOT` (env var set by test) before exit; test reads the snapshot to assert content matches `geminiPolicyTOML` constant byte-for-byte (sidesteps the `defer os.RemoveAll` race where the parent's RemoveAll fires before the test can stat the file)
+- [ ] write unit test: after Execute returns, `os.Stat($GEMINI_CLI_HOME)` returns `os.ErrNotExist` — confirms `defer os.RemoveAll(tmpHome)` ran (ephemeral-home invariant)
+- [ ] write unit test: `PermissionMode: ""` → argv = `gemini -m <model> -o text` exactly; NO `--policy` flag; policy.toml NOT written
+- [ ] write unit test: `PermissionMode: "bypassPermissions"` → argv has `--policy $GEMINI_CLI_HOME/policy.toml` as two consecutive entries; policy.toml written before gemini spawns
+- [ ] write unit test: `GEMINI_CLI_HOME` env var is a fresh tmp dir per call — two consecutive Execute calls get distinct directory paths
+- [ ] write unit test: timeout → runner timeout propagated
+- [ ] write unit test: non-zero exit no marker → error preserves exit code; NOT `*LimitError`
+- [ ] write unit test: each of 5 gemini rate-limit markers → `*LimitError{Tool:"gemini-cli", Pattern:<matched>, HelpCmd:"check https://aistudio.google.com/apikey for quota and billing"}` — one subtest per marker
+- [ ] write `gemini_live_test.go` gated by `//go:build live` + `COUNCIL_LIVE_GEMINI=1`: sends "respond with the word OK"; asserts stdout contains `OK`
+- [ ] implement `pkg/executor/gemini/gemini.go`:
+  - `type Gemini struct { Binary string }`
+  - `init() { executor.Register(&Gemini{}) }`
+  - `Name() → "gemini-cli"`, `BinaryName() → "gemini"`, `MapModel → identity`
+  - `const geminiPolicyTOML = "[[rule]]\ntoolName = [\"google_web_search\", \"web_fetch\"]\ndecision = \"allow\"\npriority = 100\n"`
+  - `Execute`: `os.MkdirTemp` for ephemeral home; `defer os.RemoveAll` (runs after `cmd.Wait` returns via `runner.Run`, so gemini atexit file-writes have completed — the subprocess wait is load-bearing); argv per spec; when `PermissionMode == "bypassPermissions"`, `os.WriteFile` policy.toml + append `--policy <path>` to argv; `env := append(os.Environ(), "GEMINI_CLI_HOME="+tmpHome)`; runner.Run with Env; wrap LimitError
+- [ ] gemini marker list as package-level `var geminiLimitPatterns = []string{...}` (the 5 patterns from ADR-0012)
+- [ ] run `go test ./pkg/executor/gemini/...` — must pass before Task 6
+
+### Task 6: cmd/council — register + preflight
+
+- [ ] write test: `executor.Get("codex")` and `executor.Get("gemini-cli")` succeed after side-effect import (integration test in `cmd/council/`)
+- [ ] write test: preflight over a profile referencing an unregistered-binary executor returns error whose message names both the binary and the profile line
+- [ ] update `cmd/council/executors_release.go`: add `_ "github.com/fitz123/council/pkg/executor/codex"` and `_ "github.com/fitz123/council/pkg/executor/gemini"`
+- [ ] implement `cmd/council/preflight.go`: `func Preflight(profile *config.Profile) error` — iterates experts; for each, gets executor via `executor.Get(expert.Executor)`; runs `exec.LookPath(ex.BinaryName())`; returns descriptive error on miss
+- [ ] wire `Preflight` call in `cmd/council/main.go` before fan-out (after profile load, before `debate.Run*`)
+- [ ] run `go test ./cmd/council/...` — must pass before Task 7
+
+### Task 7: cmd/council/init — subcommand
+
+- [ ] write test: idempotent — file exists at target → exits 0 with "profile exists" message, no overwrite
+- [ ] write test: `--force` overwrites existing file
+- [ ] write test: detection path — `executor.Register` + `exec.LookPath` stubs → generated profile contains only registered+available CLIs
+- [ ] write test: injected `probeFn` returning non-OK output for one CLI → that CLI excluded from profile
+- [ ] write test: zero-verified → exits non-zero with "install at least one of ..." message
+- [ ] write test: quorum scaling — 3 verified → quorum 2; 2 verified → quorum 2; 1 verified → quorum 1
+- [ ] write test: generated YAML round-trips through `pkg/config.LoadFile` (round-trip IS the gate that detects any validator-vs-init mismatch)
+- [ ] write test: `HOME=$tmp` override — init writes to `$tmp/.config/council/default.yaml` (not the real user home)
+- [ ] **relax `pkg/config.Validate`** (`pkg/config/loader.go:232`): change `len(experts) >= 2` → `len(experts) >= 1`. Single-expert profile is a legitimate outcome of `council init` when only one CLI is authed. v2's N>=2 invariant was chosen when council was claude-only + always 3-expert; v3's init may produce N=1 profiles. Update validator test to match.
+- [ ] implement `cmd/council/init.go`:
+  - `func runInit(force bool) error` entry point
+  - path: `filepath.Join(os.UserHomeDir(), ".config", "council", "default.yaml")` — but expose a `homeDir func() (string, error) = os.UserHomeDir` package var so tests override
+  - **probe injection seam:** `type probeFunc func(ex executor.Executor, model string, timeout time.Duration) (ok bool, reason string)`; package-level `var probe probeFunc = liveProbe`; `liveProbe` calls real `executor.Execute` via temp stdout/stderr file; tests override to deterministic stub
+  - **probes run in parallel** via `errgroup.Group`; total wall-clock ≤ 30s per slowest CLI (each per-CLI probe has its own `context.WithTimeout(30*time.Second)`)
+  - generates YAML using `yaml.v3` with the structure from multi-cli.md §1.2
+  - summary to stdout: `verified: <cli> (<model>, <elapsed>)` per verified CLI; `skipped: <cli> (<reason>)` per unverified; trailing `wrote <path> with N experts, quorum M`
+- [ ] wire `init` subcommand dispatch in `cmd/council/main.go`: place BEFORE the existing `resume` subcommand check (around `main.go:78`) — mirror the `runResume` factoring (extract to `runInit` in init.go)
+- [ ] run `go test ./cmd/council/... ./pkg/config/...` — must pass before Task 8
+
+### Task 8: pkg/debate + pkg/session — orchestrator rate-limit handling
+
+- [ ] write test: expert returning `*LimitError` → treated as failed survivor; collected into per-round `[]*LimitError`
+- [ ] write test: quorum met despite rate-limits → verdict produced with `rate_limits` populated; status `success`
+- [ ] write test: quorum unmet AND at least one failure is `*LimitError` → debate.Run* returns `ErrRateLimitQuorumFail` with the slice attached
+- [ ] write test: `errors.Is(err, ErrRateLimitQuorumFail) && !errors.Is(err, ErrQuorumFailedR1)` and `!errors.Is(err, ErrQuorumFailedR2)` — new sentinel is DISTINCT from existing quorum-fail sentinels
+- [ ] write test: quorum unmet but NO `*LimitError` in the failures → returns existing `ErrQuorumFailedR1` / `ErrQuorumFailedR2` (not the new sentinel)
+- [ ] write test: happy-path verdict.json has NO `rate_limits` key (JSON `omitempty` tag verification — avoids regressing existing F-tests on verdict shape)
+- [ ] update `pkg/debate/rounds.go` `RunRound1` / `RunRound2`: classify expert errors via `errors.As(err, &limitErr)`; accumulate `[]*LimitError`; on survivors < quorum + non-empty slice, return new `ErrRateLimitQuorumFail` sentinel
+- [ ] update `pkg/debate/vote.go` similarly for ballot path (though ballot has `AllowedTools: nil` so rate-limits less likely — still classified)
+- [ ] update `pkg/session/verdict.go`: add `RateLimits []RateLimitEntry \`json:"rate_limits,omitempty"\`` top-level field with `{Executor, Pattern, HelpCmd, Round int, Expert string}` — `omitempty` critical to avoid regressing existing verdict.json shape assertions
+- [ ] update `cmd/council/main.go`: on `errors.Is(err, debate.ErrRateLimitQuorumFail)`, print per-CLI help footer to stderr (one line per unique executor in the slice); exit with new `ExitRateLimitQuorumFail = 6`
+- [ ] update `cmd/council/main_test.go` for the new exit code path
+- [ ] run `go test ./...` (broader than per-package — security and orchestrator work need cross-layer verification) — must pass before Task 9
+
+### Task 9: test/smoke — F14 live multi-CLI smoke
+
+- [ ] write `test/smoke/F14_live_multi_cli.sh`:
+  - header: `if [ "$COUNCIL_LIVE_ALL" != "1" ]; then echo "skipping F14 (set COUNCIL_LIVE_ALL=1)"; exit 0; fi`
+  - after header: assert all three per-CLI gates set — `for v in COUNCIL_LIVE_CLAUDE COUNCIL_LIVE_CODEX COUNCIL_LIVE_GEMINI; do eval "x=\$$v"; [ "$x" = "1" ] || { echo "FAIL: $v must also be 1"; exit 2; }; done`
+  - **HOME override:** `tmp_home=$(mktemp -d); HOME=$tmp_home ./council init` — asserts yaml file exists at `$tmp_home/.config/council/default.yaml` with 3 experts (`grep -c 'executor:' "$tmp_home/.config/council/default.yaml"` equals 3)
+  - runs `HOME=$tmp_home ./council "What is the current stable Go version? Cite a URL."`; asserts exit 0; asserts `verdict.json` (via `jq`) has 3 expert sections under `rounds[1].experts`; asserts final answer contains at least one `https://` (via `grep -qE 'https?://' output.md`)
+  - cleanup: `rm -rf "$tmp_home"` on exit (trap)
+- [ ] add F14 entry to `test/smoke/run.sh` (gated, skipped silently when env unset; per webfetch §7 gating convention)
+- [ ] run `go test ./...` to verify smoke-layer additions do not break existing suite — must pass before Task 10
+
+### Task 10: docs — extract ADRs + supplement from multi-cli.md
+
+- [ ] extract `docs/adr/0012-multi-cli-executors.md` from multi-cli.md's ADR-0012 section
+- [ ] extract `docs/adr/0013-no-runner-ratelimit-retries.md` from multi-cli.md's ADR-0013 section
+- [ ] extract `docs/design/v3-multi-cli.md` from multi-cli.md's supplement section
+- [ ] update `docs/design/v2.md`:
+  - §1.4: remove "single-vendor" caveat; add paragraph referencing v3 lift (ADR-0012)
+  - §4: add D22 (BinaryName on Executor interface), D23 (rate-limit policy shift), D24 (council init subcommand)
+  - §5: append v4 deferrals (per-expert executor asymmetry, session-level retry, MCP plugins)
+  - §6.3: add exit code 6
+  - §8: append F18–F35 (from ADR-0012 and ADR-0013 fitness tables)
+  - §9: append ADR-0012, ADR-0013, v3-multi-cli.md as derivatives
+- [ ] update `docs/adr/0005-single-cli-multiple-personas.md`: add "**Status:** Superseded by ADR-0012 (2026-04-25)" note at the top (keep history)
+- [ ] update `README.md` getting-started: list three CLIs with install commands (`claude` official docs link; `brew install codex`; `brew install gemini-cli`); authentication (`claude /login`; `codex login`; gemini run-once OAuth); `council init`; first question
+- [ ] delete scratch file `/Users/ninja/council/multi-cli.md` (contents now live in docs/)
+- [ ] run `go test ./...` (doc changes should not affect tests but `embed_test.go` substring assertions might trigger) — must pass
+
+### Task 11: Verify acceptance criteria
+
+- [ ] verify all ADR-0012 fitness functions (F18–F30) have corresponding test code
+- [ ] verify all ADR-0013 fitness functions (F31–F35) have corresponding test code
+- [ ] verify F14 smoke script is executable and gated correctly
+- [ ] run full test suite `go test ./...` — green
+- [ ] run existing smoke tests `bash test/smoke/run.sh` — F1–F17 pass (F17 from webfetch), F14 auto-skipped without `COUNCIL_LIVE_ALL`
+- [ ] run linter (if project has one: `golangci-lint run` or equivalent) — zero issues
+- [ ] verify coverage ≥80% per new/modified package: `go test -cover ./pkg/executor/codex/...` etc.
+
+## Technical Details
+
+**ADR-0012 translation table** (codified in executor code):
+
+| Webfetch constant | claude-code | codex | gemini-cli |
+|---|---|---|---|
+| `AllowedTools=["WebSearch","WebFetch"]` | `--allowedTools WebSearch,WebFetch` | `-c tools.web_search=true` (any web tool triggers; single flag) | writes policy TOML + `--policy <file>` |
+| `PermissionMode="bypassPermissions"` | `--permission-mode bypassPermissions` | (no flag — sandbox+ephemeral already cover it) | triggers policy-file write; emits `--policy` |
+| Ephemeral session | `--no-session-persistence` | `--ephemeral` | `GEMINI_CLI_HOME=<MkdirTemp>` env var + defer RemoveAll |
+
+**Rate-limit marker lists** (per-executor, from primary sources):
+
+- claude-code: `you've hit your limit`, `usage limit exceeded`, `anthropic rate limit` (HelpCmd: `claude /usage`)
+- codex: `you've hit your usage limit`, `quota exceeded. check your plan`, `selected model is at capacity`, `exceeded retry limit, last status: 429`, `upgrade to plus to continue`, fallback regex `(?i)rate[_ ]?limit|insufficient_quota|usage_limit_reached` (HelpCmd: `codex /status`)
+- gemini-cli: `RESOURCE_EXHAUSTED`, `QUOTA_EXHAUSTED`, `RATE_LIMIT_EXCEEDED`, `exceeded your current quota`, `Please retry in` (HelpCmd: `check https://aistudio.google.com/apikey for quota and billing`)
+
+**Generated profile shape** (written by `council init` when all three verified):
+
+```yaml
+version: 2
+name: default
+experts:
+  - { name: claude_expert, executor: claude-code,  model: opus,                   prompt_file: prompts/independent.md, timeout: 300s }
+  - { name: codex_expert,  executor: codex,        model: gpt-5.5,                prompt_file: prompts/independent.md, timeout: 300s }
+  - { name: gemini_expert, executor: gemini-cli,   model: gemini-3.1-pro-preview, prompt_file: prompts/independent.md, timeout: 300s }
+quorum: 2
+max_retries: 1
+rounds: 2
+round_2_prompt_file: prompts/peer-aware.md
+voting:
+  ballot_prompt_file: prompts/ballot.md
+  timeout: 300s
+```
+
+Subset profiles (some CLIs not verified): `quorum = min(2, len(experts))`.
+
+**Gemini policy TOML body** (embedded constant):
+
+```toml
+[[rule]]
+toolName = ["google_web_search", "web_fetch"]
+decision = "allow"
+priority = 100
+```
+
+## Post-Completion
+
+*Items requiring manual intervention, external systems, or multi-party coordination — no checkboxes, informational only.*
+
+**Pre-landing verification (run before merging):**
+
+- `COUNCIL_LIVE_CODEX=1 go test -tags live ./pkg/executor/codex/...` passes — stdout contains `OK`.
+- `COUNCIL_LIVE_GEMINI=1 go test -tags live ./pkg/executor/gemini/...` passes — stdout contains `OK`.
+- `./council init` (clean $HOME) writes yaml with one expert per authed CLI; prints per-CLI verdict; exit 0.
+- `COUNCIL_LIVE_ALL=1 ./council "What is the current stable Go version? Cite a URL."` — exit 0; 3 expert sections; ≥1 URL cited.
+- Manual sanity: `./council "write a haiku about kubernetes"` — three R1 outputs stylistically distinguishable (vendor diversity visible).
+
+**Codex-review (autonomous, per user workflow):**
+
+- Run `codex review` on the branch before opening PR; address findings.
+- Run ralph-review (parallel multi-agent code review) iteratively until clean.
+
+**Not in this plan:**
+
+- v4 items: per-expert executor asymmetry, session-level retry on rate-limit, MCP plugin support, interactive-CLI fallback, flag-translation drift detection on CLI releases.
+- Webfetch implementation — must land via its own PR first (docs/plans/2026-04-24-v2-web-tools.md).

--- a/docs/plans/2026-04-25-v3-multi-cli.md
+++ b/docs/plans/2026-04-25-v3-multi-cli.md
@@ -4,7 +4,7 @@
 
 Implement ADR-0012 (multi-CLI executors — codex + gemini-cli) and ADR-0013 (no runner-side rate-limit retries) on top of the merged webfetch changes. Net delta: v2 debate engine's three experts now run on three different vendors (Anthropic / OpenAI / Google), each translating webfetch's hardcoded `AllowedTools = ["WebSearch", "WebFetch"]` + `PermissionMode = "bypassPermissions"` into its CLI's native tool-enablement surface. Rate-limit failures on any single CLI are absorbed by quorum instead of retried; if quorum fails because of rate-limits, new exit code 6 with per-CLI help footer.
 
-**Source of truth:** `/Users/ninja/council/multi-cli.md` (approved design package, 2026-04-25). Authoritative ADRs + supplement to be extracted into `docs/adr/0012-*.md`, `docs/adr/0013-*.md`, `docs/design/v3-multi-cli.md` as part of Task 9.
+**Source of truth:** the in-repo ADR / design docs: `docs/adr/0012-multi-cli-executors.md`, `docs/adr/0013-no-runner-ratelimit-retries.md`, and `docs/design/v3-multi-cli.md`. These were extracted from a pre-PR scratch design package; Task 10 below covers any final alignment edits between the ADRs and the implementation.
 
 **Hard prerequisite:** webfetch implementation (`docs/plans/2026-04-24-v2-web-tools.md`) MUST land on main before Task 1 of this plan. Multi-cli inherits `Request.AllowedTools` + `Request.PermissionMode` fields, ballot `AllowedTools: nil` invariant, 300s shipped timeout, updated prompts (`independent.md` / `peer-aware.md`), and ADR-0011's nonce-every-fence regex tightening. Starting this plan before webfetch lands produces uncompilable intermediate state.
 
@@ -12,7 +12,7 @@ Implement ADR-0012 (multi-CLI executors — codex + gemini-cli) and ADR-0013 (no
 
 **Smoke-verified 2026-04-25** on live CLIs (proves translation contracts before code is written):
 
-- codex-cli 0.124.0: `echo "..." | codex exec -c 'tools.web_search=true' --skip-git-repo-check -s read-only --color never --ephemeral -m gpt-5.5 -` → URL-cited answer, clean stdout.
+- codex-cli 0.124.0: `echo "..." | codex exec -c 'tools.web_search=true' --skip-git-repo-check --sandbox read-only --color never --ephemeral -m gpt-5.5 -` → URL-cited answer, clean stdout.
 - gemini-cli 0.38.2: `echo "..." | gemini -m gemini-3.1-pro-preview -o text --policy <policy.toml>` with `[[rule]] toolName=["google_web_search","web_fetch"] decision="allow" priority=100` → URL-cited answer, no deprecation warnings.
 
 **Files touched by this plan:**
@@ -209,7 +209,7 @@ Implement ADR-0012 (multi-CLI executors — codex + gemini-cli) and ADR-0013 (no
   - §9: append ADR-0012, ADR-0013, v3-multi-cli.md as derivatives
 - [ ] update `docs/adr/0005-single-cli-multiple-personas.md`: add "**Status:** Superseded by ADR-0012 (2026-04-25)" note at the top (keep history)
 - [ ] update `README.md` getting-started: list three CLIs with install commands (`claude` official docs link; `brew install codex`; `brew install gemini-cli`); authentication (`claude /login`; `codex login`; gemini run-once OAuth); `council init`; first question
-- [ ] delete scratch file `/Users/ninja/council/multi-cli.md` (contents now live in docs/)
+- note: the `multi-cli.md` scratch at repo root (if it exists in an operator's working tree) is optional personal cleanup — its contents now live in `docs/adr/0012-*.md`, `docs/adr/0013-*.md`, and `docs/design/v3-multi-cli.md`. Not a plan-task-gated action since the scratch file is untracked and may not exist in any given checkout.
 - [ ] run `go test ./...` (doc changes should not affect tests but `embed_test.go` substring assertions might trigger) — must pass
 
 ### Task 11: Verify acceptance criteria


### PR DESCRIPTION
## Summary

- ADR-0012 adds `codex` + `gemini-cli` executors (supersedes ADR-0005's single-CLI constraint); default `council init`-generated profile fans out across claude-opus + gpt-5.5 + gemini-3.1-pro-preview for cross-vendor model diversity per Zhang et al. 2025
- ADR-0013 removes runner-side 429 retry loop — rate-limit becomes a typed error the orchestrator absorbs via quorum; new exit code 6 with ralphex-style help footer when quorum fails due to rate-limits
- `council init` subcommand auto-detects CLIs, runs parallel 30s live-probes, writes `~/.config/council/default.yaml` with one expert per verified CLI (quorum = min(2, N))
- Each executor translates webfetch's hardcoded `AllowedTools` + `PermissionMode` to native flags: codex `-c tools.web_search=true`, gemini `--policy <file>` via Policy Engine TOML (forward-compatible replacement for deprecated `--allowed-tools`/`--yolo`)
- Smoke-verified 2026-04-25 against codex-cli 0.124.0 and gemini-cli 0.38.2 — both produced URL-cited answers with clean stdout
- 11-task TDD ralphex plan at `docs/plans/2026-04-25-v3-multi-cli.md`; autonomous Opus review found 2 BLOCKERs + 5 HIGHs + 5 MEDIUMs, all applied before opening this PR
- Hard prerequisite for implementation: webfetch (`docs/plans/2026-04-24-v2-web-tools.md`) must land on main first — multi-cli inherits `Request.AllowedTools`/`PermissionMode` fields, ballot tools-off invariant, 300s timeout default, and ADR-0011's nonce-every-fence regex tightening

## Test plan

This is a docs-only PR; no code changes to test. Implementation PR follows.

- [x] Smoke-verified live codex web_search + gemini web_fetch with production argv (2026-04-25)
- [x] Autonomous Opus review of ralphex plan — all BLOCKER/HIGH findings resolved
- [x] Model IDs verified: `claude opus`, `codex -m gpt-5.5`, `gemini -m gemini-3.1-pro-preview`
- [x] Extracted ADR + design files round-trip cleanly from `multi-cli.md` scratch doc

## Files

- NEW `docs/adr/0012-multi-cli-executors.md`
- NEW `docs/adr/0013-no-runner-ratelimit-retries.md`
- NEW `docs/design/v3-multi-cli.md` (supplement to v2.md)
- NEW `docs/plans/2026-04-25-v3-multi-cli.md` (ralphex implementation plan)
- MODIFIED `docs/adr/0005-single-cli-multiple-personas.md` (superseded annotation)
- MODIFIED `docs/design/v2.md` (§1.4 strike-out of single-vendor caveat; §7.3 exit code 6)

Remaining v2.md integration (§4 D22/D23/D24, §5 v4 deferrals, §8 F18-F35, §9 derivatives) happens during implementation Task 10 of the ralphex plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)