### PR TITLE
feat: --verbose closes with verdict block (winner + answer body)

### DIFF
--- a/cmd/council/main.go
+++ b/cmd/council/main.go
@@ -490,19 +490,26 @@ func logEnd(w io.Writer, sess *session.Session, v *session.Verdict) {
 	fmt.Fprintf(w, "[%s] session folder: %s\n", ts, sess.Path)
 }
 
-// logArtifacts dumps each expert's round output and per-voter ballot blocks
-// to w after the timing summary. Lets a verbose run answer "who said what
-// and who voted for whom" without having to open files in the session folder.
-// Each section is independent: rounds with no readable output.md are skipped,
-// individual unreadable per-expert output.md files are skipped, and the
-// ballot section emits whenever v.Voting.Ballots is populated even if no
-// rounds completed (e.g. resumed session that only re-ran the voting stage).
-// All artifact bodies are scrubbed of C0/DEL control bytes via
-// stripControlBytes before being written, so a malicious or malformed LLM
-// output cannot rewrite the operator's terminal state via ANSI/OSC escapes.
+// logArtifacts dumps each expert's round output, per-voter ballot blocks,
+// and the final verdict to w after the timing summary. Lets a verbose run
+// answer "who said what, who voted for whom, and what won" without having
+// to open files in the session folder or splice stdout against stderr.
+// Each section is independent: rounds with no readable output.md are
+// skipped, individual unreadable per-expert output.md files are skipped,
+// the ballot section emits whenever v.Voting.Ballots is populated even if
+// no rounds completed (e.g. resumed session that only re-ran the voting
+// stage), and the verdict section emits when v.Voting carries either a
+// winner or a tied-candidate set. All artifact bodies are scrubbed of
+// C0/DEL/C1 control bytes via stripControlBytes before being written, so
+// a malicious or malformed LLM output cannot rewrite the operator's
+// terminal state via ANSI/OSC escapes.
 func logArtifacts(w io.Writer, sess *session.Session, v *session.Verdict) {
 	if v == nil || sess == nil {
 		return
+	}
+	realName := make(map[string]string, len(v.Experts))
+	for _, e := range v.Experts {
+		realName[e.Label] = e.RealName
 	}
 	for idx, r := range v.Rounds {
 		for _, e := range r.Experts {
@@ -516,10 +523,6 @@ func logArtifacts(w io.Writer, sess *session.Session, v *session.Verdict) {
 		}
 	}
 	if v.Voting != nil && len(v.Voting.Ballots) > 0 {
-		realName := make(map[string]string, len(v.Experts))
-		for _, e := range v.Experts {
-			realName[e.Label] = e.RealName
-		}
 		for _, b := range v.Voting.Ballots {
 			fmt.Fprintf(w, "\n=== ballot %s (%s) ===\n", b.VoterLabel, realName[b.VoterLabel])
 			path := filepath.Join(sess.Path, "voting", "votes", b.VoterLabel+".txt")
@@ -538,6 +541,20 @@ func logArtifacts(w io.Writer, sess *session.Session, v *session.Verdict) {
 			if b.VotedFor == "" {
 				fmt.Fprintln(w, "(no vote — discarded)")
 			}
+		}
+	}
+	if v.Voting != nil {
+		switch {
+		case v.Voting.Winner != "":
+			fmt.Fprintf(w, "\n=== verdict (winner: %s — %s) ===\n", v.Voting.Winner, realName[v.Voting.Winner])
+			if v.Answer != "" {
+				fmt.Fprintln(w, stripControlBytes(strings.TrimRight(v.Answer, "\n")))
+			}
+		case len(v.Voting.TiedCandidates) > 0:
+			// No winner — F12 invariant means there is no single answer
+			// to dump. Surface the tie so the operator sees the closing
+			// state without having to read verdict.json.
+			fmt.Fprintf(w, "\n=== verdict (no consensus — tied: %s) ===\n", strings.Join(v.Voting.TiedCandidates, ", "))
 		}
 	}
 }

--- a/cmd/council/main_test.go
+++ b/cmd/council/main_test.go
@@ -288,6 +288,10 @@ func TestRun_Verbose(t *testing.T) {
 		// AND ballot content (happyStub emits "VOTE: A\n" for every voter).
 		"=== ballot ",
 		"VOTE: A",
+		// logArtifacts: final verdict block carries the winner label
+		// (anonymized A) plus the resolved real_name, mirrored from the
+		// stdout answer so a verbose run is self-contained on stderr.
+		"=== verdict (winner: A —",
 	} {
 		if !strings.Contains(stderr.String(), want) {
 			t.Errorf("stderr missing %q; got %s", want, stderr.String())


### PR DESCRIPTION
## Summary

The verbose stderr stream previously ended with the per-voter ballot blocks; the final answer only appeared on stdout. An operator scanning stderr for the full debate had to splice the two streams to see what won.

`logArtifacts` now appends:

```
=== verdict (winner: A — codex_expert) ===
<winning answer body>
```

after the ballots. Or, on tie:

```
=== verdict (no consensus — tied: A, B) ===
```

(no body — F12 invariant: no single answer when no winner).

If `v.Voting == nil` (R1 quorum failed before voting ever ran), the verdict section is skipped, matching the per-section "skip if absent" behavior already in place for rounds and ballots.

## Why

Verbose is meant to be self-contained — the operator wants to read stderr top-to-bottom and see the whole debate end-to-end without needing to redirect or splice stdout. Without this block, the closing state was missing.

## Implementation notes

- `realName` map (label → real_name) is hoisted to the top of `logArtifacts` so both the ballot blocks AND the verdict header can resolve labels without rebuilding the map.
- Body is the same `v.Answer` that goes to stdout, run through `stripControlBytes` for terminal safety (same protection as the round/ballot blocks).
- No schema changes. No orchestrator changes. Pure display layer.

## What it looks like

```
[12:13:39] voting: winner C
[12:13:39] session ok: 95.7s total
[12:13:39] session folder: …

=== round 1 expert A (gemini_expert) ===
…
=== ballot C (codex_expert) ===
C is the best match: it gives the current stable Go version and cites
the official downloads and release history pages…

VOTE: C

=== verdict (winner: C — codex_expert) ===
As of April 25, 2026, the latest stable Go release is Go 1.26.2…
```

## Test plan

- [x] `go test ./...` — all green; `TestRun_Verbose` extended to assert `=== verdict (winner: A —` appears on stderr
- [x] Live `./council --verbose "What is the latest stable Go version?"` against the fast-models cohort — verdict block lands at the end of stderr exactly as designed

🤖 Generated with [Claude Code](https://claude.com/claude-code)