### PR TITLE
Add Claude Code plugin with /council skills

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -1,0 +1,44 @@
+# council Claude Code Plugin
+
+This directory contains the Claude Code plugin configuration for council.
+
+## Files
+
+- `plugin.json` — Plugin manifest with metadata and version.
+- `marketplace.json` — Marketplace catalog for single-plugin distribution.
+
+## Installation
+
+Users can install via the plugin marketplace:
+
+```bash
+/plugin marketplace add fitz123/council
+/plugin install council@fitz123-council
+```
+
+## Marketplace Structure
+
+This repository serves as both:
+
+1. The council CLI tool source code.
+2. A single-plugin Claude Code marketplace.
+
+The marketplace references `./` as the plugin source. Plugin skills live in
+`assets/claude/skills/`, keeping all Claude Code related files organized
+together.
+
+## Skills
+
+| Skill              | Purpose                                              |
+|--------------------|------------------------------------------------------|
+| `/council`         | Ask the council a question and monitor progress.     |
+| `/council-init`    | Probe installed CLIs and write the per-host profile. |
+| `/council-resume`  | Resume an interrupted session.                       |
+
+## Nested Claude Code sessions
+
+`council` spawns `claude -p`, `codex`, and `gemini` subprocesses. The Claude
+Code CLI rejects nested invocation when `CLAUDECODE=1` is set. The skills
+launch council with `env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT` so the
+spawned `claude -p` subprocess does not see itself as nested. This matches
+the workaround ralphex applies inside its Go binary.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,6 +3,9 @@
   "owner": {
     "name": "fitz123"
   },
+  "metadata": {
+    "description": "Single-plugin marketplace for council — multi-expert CLI committee with two-round debate and distributed voting"
+  },
   "plugins": [
     {
       "name": "council",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "council",
+  "owner": {
+    "name": "fitz123"
+  },
+  "plugins": [
+    {
+      "name": "council",
+      "source": "./",
+      "description": "Multi-expert CLI committee — fan a question to N expert CLIs, run a two-round debate, then vote on the answer",
+      "version": "0.1.0",
+      "author": {
+        "name": "fitz123"
+      }
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "council",
+  "version": "0.1.0",
+  "description": "Multi-expert CLI committee — fan a question to N expert CLIs, run a two-round debate, then vote on the answer",
+  "author": {
+    "name": "fitz123"
+  },
+  "homepage": "https://github.com/fitz123/council",
+  "repository": "https://github.com/fitz123/council",
+  "license": "MIT",
+  "keywords": [
+    "multi-agent",
+    "debate",
+    "voting",
+    "claude-code",
+    "codex",
+    "gemini"
+  ],
+  "skills": "./assets/claude/skills/"
+}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Multi-expert CLI committee. Fan out one question to N expert CLI-instances, run 
 
 **Status:** v2 — debate engine with anonymized multi-round rounds and distributed voting.
 
+📖 **Plain-language overview (Russian):** [Council — как мы заставляем нейросети спорить](https://luck-eyeliner-26a.notion.site/Council-34d33f60dc7d8119a24fdeb30d3a5349?pvs=74) — what Council does, why voting instead of a judge, and the research backing each design decision.
+
 ## Why
 
 A single opinion from a single LLM is noisy. Running the same question through multiple expert personas, letting them critique each other's drafts in a second round, and then voting among them removes single-model bias without reintroducing a judge. Inspired by:

--- a/assets/claude/skills/council-init/SKILL.md
+++ b/assets/claude/skills/council-init/SKILL.md
@@ -47,7 +47,13 @@ word OK", 30s timeout) to confirm auth.
 Quickly surface which CLIs are present so the user knows what to expect:
 
 ```bash
-which claude codex gemini
+for b in claude codex gemini; do
+  if command -v "$b" >/dev/null 2>&1; then
+    echo "$b: $(command -v "$b")"
+  else
+    echo "$b: not found"
+  fi
+done
 ```
 
 If any are missing, mention them and link to the install instructions in the

--- a/assets/claude/skills/council-init/SKILL.md
+++ b/assets/claude/skills/council-init/SKILL.md
@@ -5,46 +5,38 @@ allowed-tools: [Bash, Read, AskUserQuestion]
 
 # council-init — Generate the Per-Host Profile
 
-**SCOPE**: This command ONLY runs `council init` and reports what it produced.
-It does NOT modify any source code or run a debate.
+**SCOPE**: Run `council init`, report what it produced. Nothing else.
 
-## Step 0: Verify CLI Installation
+## Step 0: Verify CLI
 
 ```bash
 which council
 ```
 
-**If not found**, guide installation:
+If missing: `go install github.com/fitz123/council/cmd/council@latest`.
 
-- **Any platform with Go**: `go install github.com/fitz123/council/cmd/council@latest`
+## Step 1: Probe both profile locations
 
-**Do not proceed until `which council` succeeds.**
+`council init` only writes `~/.config/council/default.yaml`, but `council`
+itself resolves profiles in this order on every run:
 
-## Step 1: Check for Existing Profile
+1. `./.council/default.yaml` (cwd-local — wins if present)
+2. `~/.config/council/default.yaml` (user-global)
+3. Embedded defaults compiled into the binary
+
+A cwd-local profile silently shadows whatever init produces. Probe both:
 
 ```bash
-ls -la ~/.config/council/default.yaml
+test -f .council/default.yaml && echo "local:  found .council/default.yaml" || echo "local:  missing .council/default.yaml"
+test -f ~/.config/council/default.yaml && echo "global: found ~/.config/council/default.yaml" || echo "global: missing ~/.config/council/default.yaml"
 ```
 
-If the file already exists, ask the user how to proceed via AskUserQuestion:
+If global exists: ask via AskUserQuestion whether to keep or regenerate
+(`Keep current` exits, `Regenerate` runs `council init --force`). If a
+local profile also exists, warn that it shadows the global one — `/council`
+will keep using the local file regardless of what init writes.
 
-- header: "Profile"
-- question: "A profile already exists at `~/.config/council/default.yaml`. Overwrite?"
-- options:
-  - label: "Keep current"
-    description: "Leave the existing profile untouched and exit"
-  - label: "Regenerate"
-    description: "Overwrite with `council init --force` (re-probes installed CLIs)"
-
-If the user picks "Keep current", report the path and stop.
-
-## Step 2: Probe and Confirm Vendor CLIs
-
-`council init` registers each executor (`claude-code`, `codex`, `gemini-cli`),
-runs `exec.LookPath` to confirm the binary, and live-probes ("respond with the
-word OK", 30s timeout) to confirm auth.
-
-Quickly surface which CLIs are present so the user knows what to expect:
+## Step 2: Surface vendor CLIs
 
 ```bash
 for b in claude codex gemini; do
@@ -56,49 +48,38 @@ for b in claude codex gemini; do
 done
 ```
 
-If any are missing, mention them and link to the install instructions in the
-README (each is subscription-based — no API keys):
+Each is subscription-based — no API keys:
 
-| Executor      | Binary   | Install                                                 | Auth                                  |
-|---------------|----------|---------------------------------------------------------|---------------------------------------|
-| `claude-code` | `claude` | See https://docs.claude.com/claude-code                 | `claude /login`                       |
-| `codex`       | `codex`  | `brew install codex` (or per-platform release)          | `codex login`                         |
-| `gemini-cli`  | `gemini` | `brew install gemini-cli` (or per-platform release)     | run `gemini` once → OAuth browser flow |
+| Executor      | Binary   | Install                                              | Auth                                      |
+|---------------|----------|------------------------------------------------------|-------------------------------------------|
+| `claude-code` | `claude` | https://docs.claude.com/claude-code                  | `claude /login`                           |
+| `codex`       | `codex`  | `brew install codex` (or per-platform release)       | `codex login`                             |
+| `gemini-cli`  | `gemini` | `brew install gemini-cli` (or per-platform release)  | run `gemini` once → OAuth browser flow    |
 
-Proceed regardless — `council init` happily writes a profile with whatever
-subset of CLIs is actually verified, and the embedded fallback is claude-only.
+Proceed regardless — init writes a profile with whatever subset is verified.
 
 ## Step 3: Run init
 
-Run synchronously (init is fast — it's just a probe + file write). Strip
-`CLAUDECODE` and `CLAUDE_CODE_ENTRYPOINT` so the live-probe of the
-`claude-code` executor (which spawns `claude -p`) does not trip the nested-CLI
-guard:
+Strip `CLAUDECODE` so the live-probe of the `claude-code` executor (which
+spawns `claude -p`) does not trip the nested-CLI guard:
 
 ```bash
 env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT council init
 ```
 
-…or, if the user picked "Regenerate" in Step 1:
-
-```bash
-env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT council init --force
-```
-
-Report any verified / skipped CLIs from the command's stderr output. Skipped
-CLIs are reported with a reason (binary not on PATH, auth probe failed, etc.).
+…or `council init --force` when regenerating. Report verified / skipped
+CLIs from stderr.
 
 ## Step 4: Confirm
-
-Show the resulting profile path and quorum sizing:
 
 ```bash
 ls -la ~/.config/council/default.yaml
 head -20 ~/.config/council/default.yaml
 ```
 
-Quorum scales as `min(2, len(verified))`. Zero verified CLIs is a hard error —
-council exits non-zero with an "install at least one of …" message.
+If `./.council/default.yaml` exists, repeat the shadowing warning — `/council`
+will keep using the local file until it is removed or edited.
 
-After reporting, STOP. Do not offer to run a debate; the user can invoke
-`/council` next if they want.
+Quorum scales as `min(2, len(verified))`. Zero verified is a hard error.
+
+**STOP.** Do not offer to run a debate.

--- a/assets/claude/skills/council-init/SKILL.md
+++ b/assets/claude/skills/council-init/SKILL.md
@@ -64,16 +64,19 @@ subset of CLIs is actually verified, and the embedded fallback is claude-only.
 
 ## Step 3: Run init
 
-Run synchronously (init is fast — it's just a probe + file write):
+Run synchronously (init is fast — it's just a probe + file write). Strip
+`CLAUDECODE` and `CLAUDE_CODE_ENTRYPOINT` so the live-probe of the
+`claude-code` executor (which spawns `claude -p`) does not trip the nested-CLI
+guard:
 
 ```bash
-council init
+env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT council init
 ```
 
 …or, if the user picked "Regenerate" in Step 1:
 
 ```bash
-council init --force
+env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT council init --force
 ```
 
 Report any verified / skipped CLIs from the command's stderr output. Skipped

--- a/assets/claude/skills/council-init/SKILL.md
+++ b/assets/claude/skills/council-init/SKILL.md
@@ -1,0 +1,95 @@
+---
+description: Probe installed CLIs and write the per-host council profile
+allowed-tools: [Bash, Read, AskUserQuestion]
+---
+
+# council-init — Generate the Per-Host Profile
+
+**SCOPE**: This command ONLY runs `council init` and reports what it produced.
+It does NOT modify any source code or run a debate.
+
+## Step 0: Verify CLI Installation
+
+```bash
+which council
+```
+
+**If not found**, guide installation:
+
+- **Any platform with Go**: `go install github.com/fitz123/council/cmd/council@latest`
+
+**Do not proceed until `which council` succeeds.**
+
+## Step 1: Check for Existing Profile
+
+```bash
+ls -la ~/.config/council/default.yaml
+```
+
+If the file already exists, ask the user how to proceed via AskUserQuestion:
+
+- header: "Profile"
+- question: "A profile already exists at `~/.config/council/default.yaml`. Overwrite?"
+- options:
+  - label: "Keep current"
+    description: "Leave the existing profile untouched and exit"
+  - label: "Regenerate"
+    description: "Overwrite with `council init --force` (re-probes installed CLIs)"
+
+If the user picks "Keep current", report the path and stop.
+
+## Step 2: Probe and Confirm Vendor CLIs
+
+`council init` registers each executor (`claude-code`, `codex`, `gemini-cli`),
+runs `exec.LookPath` to confirm the binary, and live-probes ("respond with the
+word OK", 30s timeout) to confirm auth.
+
+Quickly surface which CLIs are present so the user knows what to expect:
+
+```bash
+which claude codex gemini
+```
+
+If any are missing, mention them and link to the install instructions in the
+README (each is subscription-based — no API keys):
+
+| Executor      | Binary   | Install                                                 | Auth                                  |
+|---------------|----------|---------------------------------------------------------|---------------------------------------|
+| `claude-code` | `claude` | See https://docs.claude.com/claude-code                 | `claude /login`                       |
+| `codex`       | `codex`  | `brew install codex` (or per-platform release)          | `codex login`                         |
+| `gemini-cli`  | `gemini` | `brew install gemini-cli` (or per-platform release)     | run `gemini` once → OAuth browser flow |
+
+Proceed regardless — `council init` happily writes a profile with whatever
+subset of CLIs is actually verified, and the embedded fallback is claude-only.
+
+## Step 3: Run init
+
+Run synchronously (init is fast — it's just a probe + file write):
+
+```bash
+council init
+```
+
+…or, if the user picked "Regenerate" in Step 1:
+
+```bash
+council init --force
+```
+
+Report any verified / skipped CLIs from the command's stderr output. Skipped
+CLIs are reported with a reason (binary not on PATH, auth probe failed, etc.).
+
+## Step 4: Confirm
+
+Show the resulting profile path and quorum sizing:
+
+```bash
+ls -la ~/.config/council/default.yaml
+head -20 ~/.config/council/default.yaml
+```
+
+Quorum scales as `min(2, len(verified))`. Zero verified CLIs is a hard error —
+council exits non-zero with an "install at least one of …" message.
+
+After reporting, STOP. Do not offer to run a debate; the user can invoke
+`/council` next if they want.

--- a/assets/claude/skills/council-resume/SKILL.md
+++ b/assets/claude/skills/council-resume/SKILL.md
@@ -6,114 +6,98 @@ allowed-tools: [Bash, Read, AskUserQuestion, TaskOutput, Glob]
 
 # council-resume — Continue an Interrupted Session
 
-**SCOPE**: This command ONLY launches `council resume`, monitors progress, and
-reports status. It does NOT modify any source code.
+**SCOPE**: Launch `council resume`, monitor, report. Do nothing else.
 
-`council resume` is idempotent on per-stage `.done` markers — already-finished
-experts and ballots are reused rather than respawned, so there's no penalty
-for resuming.
+`council resume` is idempotent on per-stage `.done` markers — finished
+experts and ballots are reused, not respawned.
 
-## Step 0: Verify CLI Installation
+## Step 0: Verify CLI
 
 ```bash
 which council
 ```
 
-**If not found**, guide installation as in `/council`. Do not proceed until
-`which council` succeeds.
+If missing: see `/council` Step 0. Do not proceed until `which council`
+succeeds.
 
 ## Step 1: Pick a Session
 
-If `$ARGUMENTS` is non-empty, treat it as the session ID and pass it via
-`--session <id>` in Step 2 — `council resume` does **not** accept a positional
-session argument; the only positional/flag form it supports is `--session`.
+If `$ARGUMENTS` is non-empty, treat it as the session ID — pass it via
+`--session "$id"` (council resume rejects positional session args).
 
-Otherwise, list candidate session directories. Guard the listing so a fresh
-repo (no `.council/sessions/` yet) reports cleanly instead of erroring:
+Otherwise list candidates without erroring on a fresh repo:
 
 ```bash
 test -d .council/sessions && ls -1t .council/sessions/ || echo "no sessions yet"
 ```
 
-Use Glob `.council/sessions/*/` to enumerate candidates, then apply council's
-own resumable predicate (D14, see `pkg/session/resume.go`) so you don't offer
-sessions `--session <id>` will reject:
+A session is **resumable** (D14 predicate, `pkg/session/resume.go`) iff:
 
-- skip if the session has a top-level `.done` marker,
-- skip if `verdict.json` has a final `status` (`ok`, `no_consensus`,
+- no top-level `.done` marker, AND
+- `verdict.json.status` is not one of `ok`, `no_consensus`,
   `quorum_failed_round_1`, `quorum_failed_round_2`,
-  `injection_suspected_in_question`, `config_error`, `error`),
-- skip if no stage `.done` exists anywhere under `rounds/` (nothing has
-  progressed yet — council requires at least one stage to be cached before
-  resume is meaningful),
-- otherwise: resumable candidate.
+  `injection_suspected_in_question`, `config_error`, `error`, AND
+- at least one stage `.done` exists somewhere under `rounds/`.
 
-Show up to 4 most recent resumable candidates and ask the user via
-AskUserQuestion which to resume — or "Newest" to let council pick.
+Show up to 4 most recent resumable sessions via AskUserQuestion (plus
+"Newest" → let council pick). If none, council exits 1 (`no resumable
+session`) — report and stop.
 
-If there are no resumable sessions, council will exit with code 1 ("no
-resumable session"). Report that and stop.
-
-## Step 2: Launch council resume in Background
-
-Always pass `-v`. Always strip `CLAUDECODE` and `CLAUDE_CODE_ENTRYPOINT` so
-the spawned `claude -p` subprocess does not trip the nested-CLI guard. If the
-user supplied a session ID in `$ARGUMENTS`, pass it via `--session <id>`
-(never positionally — council will reject):
+## Step 2: Launch (background)
 
 ```bash
-mkdir -p .council
-env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT council resume -v \
-  [--session <id>] \
-  >.council/last-stdout.txt 2>.council/last-stderr.log
+errlog=$(mktemp /tmp/council-resume-stderr.XXXXXXXX)
+echo "$errlog"
 ```
 
-Run via the Bash tool with `run_in_background: true`. **Save the task_id from
-the response** — you need it for the status check.
+Pick **one** of the two forms below (never use `[…]` placeholder syntax in
+the bash you actually run):
+
+**A — newest resumable** (no `$ARGUMENTS`):
+
+```bash
+env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT council resume -v \
+  > /dev/null 2> "$errlog"
+```
+
+**B — explicit session ID**:
+
+```bash
+SESSION="<the-validated-session-id>"
+env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT council resume -v --session "$SESSION" \
+  > /dev/null 2> "$errlog"
+```
+
+Run with `run_in_background: true`. **Save the `task_id` and `$errlog`.**
 
 ## Step 3: Confirm Launch
 
-1. Wait 10–15 seconds for resume to settle.
-2. Read the first 5 lines of `.council/last-stderr.log` to see which session
-   council picked up and which stages it's reusing from cache.
-3. Report:
+After 10–15s, read first 5 lines of `$errlog` → which session and which
+stages are reused from cache. Report:
 
 ```
 council resume started. Task ID: <task_id>
-
 Session: <session-id>
-Resuming stages: <summary from stderr — e.g. "round 2 expert A reused from cache, round 2 expert B fresh">
-Verbose log: .council/last-stderr.log
+Resuming: <e.g. "round 2 expert A reused, expert B fresh">
+Session folder: ./.council/sessions/<session-id>/
+Verbose log: <errlog>
 
-Manual monitoring:
-  tail -f .council/last-stderr.log
+Manual: tail -f <errlog>
 ```
 
-**STOP HERE. Do not continue monitoring automatically.**
+**STOP.** Do not poll automatically.
 
-## Step 4: Progress Check (only on explicit user request)
+## Step 4: Status (on explicit user request)
 
-Same protocol as `/council`:
+Same protocol as `/council` Step 4 — `TaskOutput`, tail of `$errlog`,
+report phase or final outcome. Exit codes are identical:
 
-1. TaskOutput with `block: false`.
-2. Read the last 40 lines of `.council/last-stderr.log`.
-3. Report current phase, or final status when the process has exited.
-
-Exit codes are identical to `/council`:
-
-| Code | Meaning |
-|------|---------|
-| 0    | Winner printed to `.council/last-stdout.txt`. |
+| Exit | Action |
+|------|--------|
+| 0    | Read `./.council/sessions/<id>/output.md` and print it. |
 | 1    | Config error or no resumable session. |
-| 2    | Quorum unmet, or ballots tied (no consensus). |
-| 6    | Rate-limit quorum failure (per-CLI footer in stderr). |
+| 2    | Quorum unmet, or ballots tied. |
+| 6    | Rate-limit quorum failure. |
 | 130  | Interrupted again — re-run `/council-resume`. |
 
-**After reporting status, STOP. Do not offer to do anything else.**
-
-## Constraints
-
-- This command is ONLY for resuming and monitoring an interrupted council run.
-- Do NOT offer to help with code or run a fresh debate.
-- After launch confirmation: wait for the user to explicitly request status.
-- After status check: report and stop.
+Then **STOP**.

--- a/assets/claude/skills/council-resume/SKILL.md
+++ b/assets/claude/skills/council-resume/SKILL.md
@@ -24,26 +24,42 @@ which council
 
 ## Step 1: Pick a Session
 
-If `$ARGUMENTS` is non-empty, treat it as the session ID and skip selection.
+If `$ARGUMENTS` is non-empty, treat it as the session ID and pass it via
+`--session <id>` in Step 2 — `council resume` does **not** accept a positional
+session argument; the only positional/flag form it supports is `--session`.
 
-Otherwise, list incomplete sessions (those without a root `.done` marker):
+Otherwise, list candidate session directories. Guard the listing so a fresh
+repo (no `.council/sessions/` yet) reports cleanly instead of erroring:
 
 ```bash
-ls -1t .council/sessions/
+test -d .council/sessions && ls -1t .council/sessions/ || echo "no sessions yet"
 ```
 
-Use Glob `.council/sessions/*/` and exclude entries that contain a `.done`
-file at the top level. Show up to 4 most recent incomplete sessions and ask
-the user via AskUserQuestion which to resume — or "Newest" to let council
-pick.
+Use Glob `.council/sessions/*/` to enumerate candidates, then apply council's
+own resumable predicate (D14, see `pkg/session/resume.go`) so you don't offer
+sessions `--session <id>` will reject:
 
-If there are no incomplete sessions, council will exit with code 1 ("no
+- skip if the session has a top-level `.done` marker,
+- skip if `verdict.json` has a final `status` (`ok`, `no_consensus`,
+  `quorum_failed_round_1`, `quorum_failed_round_2`,
+  `injection_suspected_in_question`, `config_error`, `error`),
+- skip if no stage `.done` exists anywhere under `rounds/` (nothing has
+  progressed yet — council requires at least one stage to be cached before
+  resume is meaningful),
+- otherwise: resumable candidate.
+
+Show up to 4 most recent resumable candidates and ask the user via
+AskUserQuestion which to resume — or "Newest" to let council pick.
+
+If there are no resumable sessions, council will exit with code 1 ("no
 resumable session"). Report that and stop.
 
 ## Step 2: Launch council resume in Background
 
 Always pass `-v`. Always strip `CLAUDECODE` and `CLAUDE_CODE_ENTRYPOINT` so
-the spawned `claude -p` subprocess does not trip the nested-CLI guard.
+the spawned `claude -p` subprocess does not trip the nested-CLI guard. If the
+user supplied a session ID in `$ARGUMENTS`, pass it via `--session <id>`
+(never positionally — council will reject):
 
 ```bash
 mkdir -p .council

--- a/assets/claude/skills/council-resume/SKILL.md
+++ b/assets/claude/skills/council-resume/SKILL.md
@@ -1,0 +1,103 @@
+---
+description: Resume an interrupted council session — finish without re-running completed stages
+argument-hint: 'optional session ID (defaults to newest incomplete)'
+allowed-tools: [Bash, Read, AskUserQuestion, TaskOutput, Glob]
+---
+
+# council-resume — Continue an Interrupted Session
+
+**SCOPE**: This command ONLY launches `council resume`, monitors progress, and
+reports status. It does NOT modify any source code.
+
+`council resume` is idempotent on per-stage `.done` markers — already-finished
+experts and ballots are reused rather than respawned, so there's no penalty
+for resuming.
+
+## Step 0: Verify CLI Installation
+
+```bash
+which council
+```
+
+**If not found**, guide installation as in `/council`. Do not proceed until
+`which council` succeeds.
+
+## Step 1: Pick a Session
+
+If `$ARGUMENTS` is non-empty, treat it as the session ID and skip selection.
+
+Otherwise, list incomplete sessions (those without a root `.done` marker):
+
+```bash
+ls -1t .council/sessions/
+```
+
+Use Glob `.council/sessions/*/` and exclude entries that contain a `.done`
+file at the top level. Show up to 4 most recent incomplete sessions and ask
+the user via AskUserQuestion which to resume — or "Newest" to let council
+pick.
+
+If there are no incomplete sessions, council will exit with code 1 ("no
+resumable session"). Report that and stop.
+
+## Step 2: Launch council resume in Background
+
+Always pass `-v`. Always strip `CLAUDECODE` and `CLAUDE_CODE_ENTRYPOINT` so
+the spawned `claude -p` subprocess does not trip the nested-CLI guard.
+
+```bash
+mkdir -p .council
+env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT council resume -v \
+  [--session <id>] \
+  >.council/last-stdout.txt 2>.council/last-stderr.log
+```
+
+Run via the Bash tool with `run_in_background: true`. **Save the task_id from
+the response** — you need it for the status check.
+
+## Step 3: Confirm Launch
+
+1. Wait 10–15 seconds for resume to settle.
+2. Read the first 5 lines of `.council/last-stderr.log` to see which session
+   council picked up and which stages it's reusing from cache.
+3. Report:
+
+```
+council resume started. Task ID: <task_id>
+
+Session: <session-id>
+Resuming stages: <summary from stderr — e.g. "round 2 expert A reused from cache, round 2 expert B fresh">
+Verbose log: .council/last-stderr.log
+
+Manual monitoring:
+  tail -f .council/last-stderr.log
+```
+
+**STOP HERE. Do not continue monitoring automatically.**
+
+## Step 4: Progress Check (only on explicit user request)
+
+Same protocol as `/council`:
+
+1. TaskOutput with `block: false`.
+2. Read the last 40 lines of `.council/last-stderr.log`.
+3. Report current phase, or final status when the process has exited.
+
+Exit codes are identical to `/council`:
+
+| Code | Meaning |
+|------|---------|
+| 0    | Winner printed to `.council/last-stdout.txt`. |
+| 1    | Config error or no resumable session. |
+| 2    | Quorum unmet, or ballots tied (no consensus). |
+| 6    | Rate-limit quorum failure (per-CLI footer in stderr). |
+| 130  | Interrupted again — re-run `/council-resume`. |
+
+**After reporting status, STOP. Do not offer to do anything else.**
+
+## Constraints
+
+- This command is ONLY for resuming and monitoring an interrupted council run.
+- Do NOT offer to help with code or run a fresh debate.
+- After launch confirmation: wait for the user to explicitly request status.
+- After status check: report and stop.

--- a/assets/claude/skills/council/SKILL.md
+++ b/assets/claude/skills/council/SKILL.md
@@ -37,8 +37,11 @@ If neither file exists, the embedded fallback works but only uses `claude-code`.
 For the recommended three-CLI cohort (claude-code + codex + gemini), the user
 needs the per-host profile.
 
+Probe both candidate paths without erroring when either is missing:
+
 ```bash
-ls .council/default.yaml ~/.config/council/default.yaml
+test -f .council/default.yaml && echo "found: .council/default.yaml" || echo "missing: .council/default.yaml"
+test -f ~/.config/council/default.yaml && echo "found: ~/.config/council/default.yaml" || echo "missing: ~/.config/council/default.yaml"
 ```
 
 If both are missing and the user wants the multi-CLI default, suggest running

--- a/assets/claude/skills/council/SKILL.md
+++ b/assets/claude/skills/council/SKILL.md
@@ -1,153 +1,99 @@
 ---
 description: Ask the council a question — fan-out to N expert CLIs, two-round debate, distributed vote
 argument-hint: 'optional question text (or omit and you will be asked)'
-allowed-tools: [Bash, Read, AskUserQuestion, TaskOutput, Glob]
+allowed-tools: [Bash, Read, Write, AskUserQuestion, TaskOutput, Glob]
 ---
 
 # council — Multi-expert Debate
 
-**SCOPE**: This command ONLY launches `council`, monitors progress, and reports
-status. Do NOT take any other actions on the codebase.
+**SCOPE**: Launch `council`, monitor progress, report status. Do nothing else.
 
-## Step 0: Verify CLI Installation
-
-Check if council is on PATH:
+## Step 0: Verify CLI
 
 ```bash
 which council
 ```
 
-**If not found**, guide installation:
+If missing: `go install github.com/fitz123/council/cmd/council@latest`. Do
+not proceed until `which council` succeeds.
 
-- **Any platform with Go**: `go install github.com/fitz123/council/cmd/council@latest`
-- **From a clone**: `git clone https://github.com/fitz123/council.git && cd council && go build -o council ./cmd/council`
+## Step 1: Question
 
-Use AskUserQuestion to confirm installation method, then guide through it. **Do
-not proceed until `which council` succeeds.**
-
-## Step 1: Verify Profile
-
-council looks for a profile in this order:
-
-1. `./.council/default.yaml` (cwd-local)
-2. `~/.config/council/default.yaml` (user-global)
-3. Embedded defaults compiled into the binary (claude-code only)
-
-If neither file exists, the embedded fallback works but only uses `claude-code`.
-For the recommended three-CLI cohort (claude-code + codex + gemini), the user
-needs the per-host profile.
-
-Probe both candidate paths without erroring when either is missing:
+- `$ARGUMENTS` if non-empty, else AskUserQuestion / free-text input.
+- Write the question to a tempfile via the **Write tool** (never `echo` /
+  `printf` / heredoc — question text may contain backticks, `$(…)`, quotes,
+  or newlines that the shell would interpret):
 
 ```bash
-test -f .council/default.yaml && echo "found: .council/default.yaml" || echo "missing: .council/default.yaml"
-test -f ~/.config/council/default.yaml && echo "found: ~/.config/council/default.yaml" || echo "missing: ~/.config/council/default.yaml"
+qfile=$(mktemp /tmp/council-question.XXXXXXXX)
+echo "$qfile"
 ```
 
-If both are missing and the user wants the multi-CLI default, suggest running
-`/council-init` first and stop. If the user is fine with the embedded fallback,
-proceed.
+Then call Write with `file_path=$qfile`, `content=<raw question text>`.
 
-## Step 2: Resolve the Question
+## Step 2: Launch (background)
 
-- if `$ARGUMENTS` is non-empty: use it verbatim as the question.
-- otherwise: ask via AskUserQuestion or just prompt for free-text input.
-
-For multi-paragraph questions, write them to a temp file and pipe via `-`:
+`-v` is required for monitoring. `env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT`
+is required so the spawned `claude -p` does not trip the nested-CLI guard.
+Question goes via stdin redirection — never argv:
 
 ```bash
-cat /tmp/council-q.md | env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT council -v -
+errlog=$(mktemp /tmp/council-stderr.XXXXXXXX)
+echo "$errlog"
+env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT council -v - \
+  < "$qfile" > /dev/null 2> "$errlog"
 ```
 
-## Step 3: Launch council in Background
+Run with `run_in_background: true`. **Save the `task_id` and `$errlog`** —
+both are needed for status checks. Stdout is discarded because council
+writes the winner's body to `./.council/sessions/<id>/output.md` on success.
 
-Build the command. Always pass `-v` so per-stage progress streams to stderr.
-Always strip `CLAUDECODE` and `CLAUDE_CODE_ENTRYPOINT` so the spawned
-`claude -p` subprocess does not trip the nested-CLI guard.
+A research-heavy run takes 3–5 min wall-clock.
 
-```bash
-mkdir -p .council
-env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT council -v "<question>" \
-  >.council/last-stdout.txt 2>.council/last-stderr.log
-```
+## Step 3: Confirm Launch
 
-Run via the Bash tool with `run_in_background: true`. **Save the task_id from
-the response** — you need it for the status check.
-
-A research-heavy run takes 3–5 minutes wall-clock per the README.
-
-## Step 4: Confirm Launch
-
-1. Wait 10–15 seconds for initialization.
-2. Read the first 5 lines of `.council/last-stderr.log` to extract the session
-   ID (line 1 contains `... — session <id>`) and the profile summary (line 2).
-3. Report:
+After 10–15s, read first 5 lines of `$errlog` to extract the session ID
+(line 1: `... — session <id>`) and profile summary (line 2). Report:
 
 ```
 council started. Task ID: <task_id>
-
-Question: <first 100 chars of question>
+Question: <first 100 chars>
 Session: <session-id>
-Profile: <profile summary>
 Session folder: ./.council/sessions/<session-id>/
-Verbose log: .council/last-stderr.log
+Verbose log: <errlog>
 
-Manual monitoring:
-  tail -f .council/last-stderr.log     # live debate stream
-  tail -50 .council/last-stderr.log    # recent activity
-
-council runs autonomously (3–5 min on research questions). The process
-continues if you close this conversation.
-
-Ask "check council" to get a status update.
+Manual: tail -f <errlog>
 ```
 
-**STOP HERE. Do not continue monitoring automatically.**
+**STOP.** Do not poll automatically.
 
-## Step 5: Progress Check (only on explicit user request)
+## Step 4: Status (on explicit user request)
 
-If the user explicitly asks "check council", "council status", or
-"how is council doing":
+Trigger words: "check council", "council status", "how is council doing".
 
-1. Use TaskOutput with `block: false` to check process status (use the
-   `task_id` from Step 3).
-2. Read the last 40 lines of `.council/last-stderr.log`.
+1. `TaskOutput` (block: false) for the saved `task_id`.
+2. Read tail of `$errlog`.
 
-**If the process is still running**, infer the current phase from the most
-recent stage line:
+Running → report current phase from the most recent stage line:
 
-- `round 1 expert <X> ...` → R1 fan-out (blind round).
-- `round 2 expert <X> ...` → R2 fan-out (peer-aware round).
-- `ballot <X> voted for <Y> ...` → voting stage.
+- `round 1 expert <X> ...` → R1.
+- `round 2 expert <X> ...` → R2.
+- `ballot <X> voted for <Y> ...` → voting.
 
-Show the recent stage lines.
+Exited:
 
-**If the process exited** (TaskOutput shows completion):
+| Exit | Action |
+|------|--------|
+| 0    | Read `./.council/sessions/<id>/output.md` and print it. Tail of `$errlog` carries the verdict header. |
+| 1    | Config / preflight error — show relevant stderr lines. |
+| 2    | No consensus — point at `output-<label>.md` in the session folder. |
+| 6    | Rate-limit quorum failure — surface the per-CLI footer from `$errlog`. |
+| 130  | Interrupted — suggest `/council-resume`. |
 
-- Exit code `0` → success. Print `.council/last-stdout.txt` (winner's R2 body).
-  Mention the verdict header from the tail of `last-stderr.log`.
-- Exit code `2` → no consensus. Point at `output-<label>.md` files in the
-  session folder.
-- Exit code `6` → rate-limit quorum failure. Surface the per-CLI footer from
-  the stderr log.
-- Exit code `1` → config / preflight error. Show the relevant stderr lines.
-- Exit code `130` → interrupted. Suggest `/council-resume`.
-
-**After reporting status, STOP. Do not offer to do anything else.**
-
-## Constraints
-
-- This command is ONLY for launching and monitoring council.
-- Do NOT offer to help with code, commits, PRs, or anything else.
-- Do NOT take actions on the codebase based on the verdict.
-- After launch confirmation: wait for the user to explicitly request a status
-  check.
-- After status check: report and stop.
+Then **STOP**.
 
 ## Nested Claude Code Sessions
 
-council itself does not strip `CLAUDECODE` from child processes (unlike
-ralphex). The skill works around this by invoking council with
-`env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT`, so the spawned `claude -p`
-subprocess sees a clean environment. Running council from a standalone
-terminal is still fine — the env stripping is a no-op when the vars aren't set.
+council does not strip `CLAUDECODE` from spawned `claude -p` subprocesses
+(unlike ralphex). The `env -u` prefix is the workaround. From a standalone
+terminal it is a no-op (vars aren't set).

--- a/assets/claude/skills/council/SKILL.md
+++ b/assets/claude/skills/council/SKILL.md
@@ -1,0 +1,150 @@
+---
+description: Ask the council a question — fan-out to N expert CLIs, two-round debate, distributed vote
+argument-hint: 'optional question text (or omit and you will be asked)'
+allowed-tools: [Bash, Read, AskUserQuestion, TaskOutput, Glob]
+---
+
+# council — Multi-expert Debate
+
+**SCOPE**: This command ONLY launches `council`, monitors progress, and reports
+status. Do NOT take any other actions on the codebase.
+
+## Step 0: Verify CLI Installation
+
+Check if council is on PATH:
+
+```bash
+which council
+```
+
+**If not found**, guide installation:
+
+- **Any platform with Go**: `go install github.com/fitz123/council/cmd/council@latest`
+- **From a clone**: `git clone https://github.com/fitz123/council.git && cd council && go build -o council ./cmd/council`
+
+Use AskUserQuestion to confirm installation method, then guide through it. **Do
+not proceed until `which council` succeeds.**
+
+## Step 1: Verify Profile
+
+council looks for a profile in this order:
+
+1. `./.council/default.yaml` (cwd-local)
+2. `~/.config/council/default.yaml` (user-global)
+3. Embedded defaults compiled into the binary (claude-code only)
+
+If neither file exists, the embedded fallback works but only uses `claude-code`.
+For the recommended three-CLI cohort (claude-code + codex + gemini), the user
+needs the per-host profile.
+
+```bash
+ls .council/default.yaml ~/.config/council/default.yaml
+```
+
+If both are missing and the user wants the multi-CLI default, suggest running
+`/council-init` first and stop. If the user is fine with the embedded fallback,
+proceed.
+
+## Step 2: Resolve the Question
+
+- if `$ARGUMENTS` is non-empty: use it verbatim as the question.
+- otherwise: ask via AskUserQuestion or just prompt for free-text input.
+
+For multi-paragraph questions, write them to a temp file and pipe via `-`:
+
+```bash
+cat /tmp/council-q.md | env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT council -v -
+```
+
+## Step 3: Launch council in Background
+
+Build the command. Always pass `-v` so per-stage progress streams to stderr.
+Always strip `CLAUDECODE` and `CLAUDE_CODE_ENTRYPOINT` so the spawned
+`claude -p` subprocess does not trip the nested-CLI guard.
+
+```bash
+mkdir -p .council
+env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT council -v "<question>" \
+  >.council/last-stdout.txt 2>.council/last-stderr.log
+```
+
+Run via the Bash tool with `run_in_background: true`. **Save the task_id from
+the response** — you need it for the status check.
+
+A research-heavy run takes 3–5 minutes wall-clock per the README.
+
+## Step 4: Confirm Launch
+
+1. Wait 10–15 seconds for initialization.
+2. Read the first 5 lines of `.council/last-stderr.log` to extract the session
+   ID (line 1 contains `... — session <id>`) and the profile summary (line 2).
+3. Report:
+
+```
+council started. Task ID: <task_id>
+
+Question: <first 100 chars of question>
+Session: <session-id>
+Profile: <profile summary>
+Session folder: ./.council/sessions/<session-id>/
+Verbose log: .council/last-stderr.log
+
+Manual monitoring:
+  tail -f .council/last-stderr.log     # live debate stream
+  tail -50 .council/last-stderr.log    # recent activity
+
+council runs autonomously (3–5 min on research questions). The process
+continues if you close this conversation.
+
+Ask "check council" to get a status update.
+```
+
+**STOP HERE. Do not continue monitoring automatically.**
+
+## Step 5: Progress Check (only on explicit user request)
+
+If the user explicitly asks "check council", "council status", or
+"how is council doing":
+
+1. Use TaskOutput with `block: false` to check process status (use the
+   `task_id` from Step 3).
+2. Read the last 40 lines of `.council/last-stderr.log`.
+
+**If the process is still running**, infer the current phase from the most
+recent stage line:
+
+- `round 1 expert <X> ...` → R1 fan-out (blind round).
+- `round 2 expert <X> ...` → R2 fan-out (peer-aware round).
+- `ballot <X> voted for <Y> ...` → voting stage.
+
+Show the recent stage lines.
+
+**If the process exited** (TaskOutput shows completion):
+
+- Exit code `0` → success. Print `.council/last-stdout.txt` (winner's R2 body).
+  Mention the verdict header from the tail of `last-stderr.log`.
+- Exit code `2` → no consensus. Point at `output-<label>.md` files in the
+  session folder.
+- Exit code `6` → rate-limit quorum failure. Surface the per-CLI footer from
+  the stderr log.
+- Exit code `1` → config / preflight error. Show the relevant stderr lines.
+- Exit code `130` → interrupted. Suggest `/council-resume`.
+
+**After reporting status, STOP. Do not offer to do anything else.**
+
+## Constraints
+
+- This command is ONLY for launching and monitoring council.
+- Do NOT offer to help with code, commits, PRs, or anything else.
+- Do NOT take actions on the codebase based on the verdict.
+- After launch confirmation: wait for the user to explicitly request a status
+  check.
+- After status check: report and stop.
+
+## Nested Claude Code Sessions
+
+council itself does not strip `CLAUDECODE` from child processes (unlike
+ralphex). The skill works around this by invoking council with
+`env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT`, so the spawned `claude -p`
+subprocess sees a clean environment. Running council from a standalone
+terminal is still fine — the env stripping is a no-op when the vars aren't set.


### PR DESCRIPTION
## Summary
- Ship a `.claude-plugin/` manifest + three slash-command skills under `assets/claude/skills/` so council can be installed via the Claude Code marketplace, mirroring the layout used by [umputun/ralphex](https://github.com/umputun/ralphex).
- Skills: **`/council`** (ask + monitor), **`/council-init`** (probe CLIs and write `~/.config/council/default.yaml`), **`/council-resume`** (continue an interrupted session).
- Every skill launches council with `env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT` so the spawned `claude -p` subprocess does not trip the nested-CLI guard. This is a skill-level workaround for council not stripping those vars itself (ralphex does the equivalent inside its Go binary — a follow-up to do the same in `pkg/runner` would let us drop the `env -u` prefix here).
- Per-launch `mktemp` tempfiles for the verbose stderr stream; the question is written via the Write tool to a tempfile and fed through stdin (`council -v - < "$qfile"`) so shell metacharacters in `$ARGUMENTS` cannot be interpolated. Stdout is discarded — council writes the winner's body to `./.council/sessions/<id>/output.md` and the skill reads that on completion.

## Layout
```
.claude-plugin/
  plugin.json          # manifest, "skills": "./assets/claude/skills/"
  marketplace.json     # single-plugin marketplace entry (with metadata.description)
  README.md            # plugin notes + nested-CLI workaround
assets/claude/skills/
  council/SKILL.md           # 99 lines
  council-init/SKILL.md      # 85 lines
  council-resume/SKILL.md    # 103 lines
```

## Install (after merge)
```
/plugin marketplace add fitz123/council
/plugin install council@fitz123-council
```

## Test plan
- [x] `python3 -m json.tool .claude-plugin/{plugin,marketplace}.json` parse cleanly.
- [x] `claude plugin validate .` passes clean (zero warnings) after adding `metadata.description` to marketplace.json.
- [x] All three `SKILL.md` files have valid YAML frontmatter with `description` (and `argument-hint` / `allowed-tools` where relevant).
- [x] **Nested-CLI workaround (load-bearing)**: `echo "say OK" \| env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT claude -p - --model haiku --output-format text </dev/null` returns `OK` from inside an active Claude Code session.
- [x] **End-to-end `/council` (basic)**: ran council on `"what is 2+2? respond with a single short sentence."` from inside this Claude Code session — all three experts (claude_expert, codex_expert, gemini_expert) succeeded in R1 and R2, ballots came back 3/3 for A, exit 0, 100s wall-clock.
- [x] **End-to-end `/council` (injection-safe)**: ran council on `"what does the literal string \`$(date)\` represent in shell? respond with a single short sentence."` via `mktemp` tempfile + `council -v - < "$qfile"`. The literal `$(date)` survived to council's `<session>/question.md` un-expanded; ballots came back 3/3 for B, exit 0, 39s wall-clock. Confirms the question-via-stdin pattern blocks shell interpolation.
- [x] **`/council-init` (idempotent path)**: `env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT council init` exits 0 with `profile exists at ~/.config/council/default.yaml (use --force to overwrite)` when a profile already exists.
- [x] **`/council-resume` (no-session path)**: `env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT council resume` exits 1 with `council resume: no resumable session found` when no incomplete session exists.
- [ ] **Marketplace install** (`/plugin marketplace add fitz123/council` → `/plugin install council@fitz123-council`): manual — requires the user to install in their own Claude Code session post-merge. Plugin scaffolding follows the ralphex layout exactly and `claude plugin validate .` passes.

## Review history
- **Copilot review (commit 31e07e3, 6 findings)**: 5 fixes pushed in `784c1cc` + `ef35fd2` (env stripping in `/council-init`, `test -f` instead of `ls` for missing-profile probe, `command -v` loop for missing-binary probe, `test -d` guard for missing sessions dir, full D14 predicate for resumable sessions, explicit `--session` note). 6th finding was about the missing env-strip in `/council-init` — already addressed by `784c1cc`. All 6 review threads resolved.
- **Codex adversarial review (commit ef35fd2, 4 findings + 1 plugin-validate warning)**: addressed in `101ede0`:
  - **HIGH** question argv interpolation → write to mktemp via Write tool, feed via stdin.
  - **MEDIUM** fixed `.council/last-{stdout,stderr}` collide between concurrent runs → per-launch mktemp tempfile for stderr, drop stdout (read `<session>/output.md` instead).
  - **MEDIUM** `[--session <id>]` placeholder is non-executable bash → split into two concrete forms (Form A no flag, Form B `--session "$SESSION"`).
  - **MEDIUM** `/council-init` ignored cwd-local profile shadowing → probe both paths and warn when local shadows global.
  - **WARNING** `metadata.description` missing on marketplace.json → added; `claude plugin validate .` passes clean.

  Per "keep skill minimal so claude-code can run it and know how it works", the same commit also trimmed the three SKILL.md bodies (158→99, 120→103, 87→85; total −84 lines) and reverted an earlier over-engineered `.council/plugin-runs/<ts>/` namespace in favour of council's existing `./.council/sessions/<id>/` artifacts.

## Follow-ups (separate PR)
- Strip `CLAUDECODE` / `CLAUDE_CODE_ENTRYPOINT` inside `pkg/runner` (or the executor layer) the way ralphex does; once landed, the skill bodies can drop the `env -u` prefix and the README's "Unsafe to nest" paragraph can be softened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)