### PR TITLE
feat: verbose ballot lines show candidate real name (#14)

### DIFF
--- a/cmd/council/reporter.go
+++ b/cmd/council/reporter.go
@@ -106,12 +106,13 @@ func (r *stderrReporter) renderBallot(e debate.StageEvent) {
 	ts := nowStamp()
 	switch {
 	case e.VotedFor != "":
+		candidate := formatCandidate(e.VotedFor, e.VotedForRealName)
 		if e.Resumed {
 			fmt.Fprintf(r.w, "[%s] ballot %s (%s) reused from cache, voted for %s\n",
-				ts, e.Label, e.RealName, e.VotedFor)
+				ts, e.Label, e.RealName, candidate)
 		} else {
 			fmt.Fprintf(r.w, "[%s] ballot %s (%s) voted for %s in %.1fs\n",
-				ts, e.Label, e.RealName, e.VotedFor, e.Duration.Seconds())
+				ts, e.Label, e.RealName, candidate, e.Duration.Seconds())
 		}
 	case e.LimitErr != nil:
 		fmt.Fprintf(r.w, "[%s] ballot %s (%s) discarded (rate-limited) in %.1fs\n",
@@ -127,6 +128,19 @@ func (r *stderrReporter) renderBallot(e debate.StageEvent) {
 	if e.VotedFor == "" {
 		fmt.Fprintln(r.w, "(no vote — discarded)")
 	}
+}
+
+// formatCandidate renders the chosen candidate as "X (realname)" so the
+// operator can read the live ballot line without cross-referencing
+// verdict.json's anonymization map. Falls back to the bare label when the
+// real name is unknown (e.g. a future code path that fires a ballot event
+// without populating VotedForRealName) so the line still parses cleanly
+// instead of rendering "X ()".
+func formatCandidate(label, realName string) string {
+	if realName == "" {
+		return label
+	}
+	return fmt.Sprintf("%s (%s)", label, realName)
 }
 
 // ballotRejectedLabel maps a debate.BallotRejected* constant to the

--- a/cmd/council/reporter_test.go
+++ b/cmd/council/reporter_test.go
@@ -129,12 +129,13 @@ func TestStderrReporter_Render(t *testing.T) {
 			name: "ballot voted fresh",
 			ev: debate.StageEvent{
 				Kind: "ballot", Label: "A", RealName: "codex_expert",
-				Body:     []byte("Reasoning here.\n\nVOTE: B"),
-				VotedFor: "B",
-				Duration: 12 * time.Second,
+				Body:             []byte("Reasoning here.\n\nVOTE: B"),
+				VotedFor:         "B",
+				VotedForRealName: "haiku_expert",
+				Duration:         12 * time.Second,
 			},
 			mustContain: []string{
-				"[12:00:00] ballot A (codex_expert) voted for B in 12.0s",
+				"[12:00:00] ballot A (codex_expert) voted for B (haiku_expert) in 12.0s",
 				"=== ballot A (codex_expert) ===",
 				"Reasoning here.",
 				"VOTE: B",
@@ -145,17 +146,31 @@ func TestStderrReporter_Render(t *testing.T) {
 			name: "ballot voted resumed",
 			ev: debate.StageEvent{
 				Kind: "ballot", Label: "C", RealName: "haiku",
-				Body:     []byte("Cached ballot text\n\nVOTE: A"),
-				VotedFor: "A",
-				Resumed:  true,
+				Body:             []byte("Cached ballot text\n\nVOTE: A"),
+				VotedFor:         "A",
+				VotedForRealName: "codex_expert",
+				Resumed:          true,
 			},
 			mustContain: []string{
-				"reused from cache, voted for A",
+				"reused from cache, voted for A (codex_expert)",
 				"=== ballot C (haiku) ===",
 				"Cached ballot text",
 				"VOTE: A",
 			},
 			mustOmit: []string{"voted for A in", "discarded"},
+		},
+		{
+			name: "ballot voted fresh missing real name falls back to bare label",
+			ev: debate.StageEvent{
+				Kind: "ballot", Label: "A", RealName: "codex_expert",
+				Body:     []byte("VOTE: B"),
+				VotedFor: "B",
+				Duration: 8 * time.Second,
+			},
+			mustContain: []string{
+				"[12:00:00] ballot A (codex_expert) voted for B in 8.0s",
+			},
+			mustOmit: []string{"voted for B (", "voted for B ()"},
 		},
 		{
 			name: "ballot discarded rate-limited",

--- a/pkg/debate/reporter.go
+++ b/pkg/debate/reporter.go
@@ -63,6 +63,14 @@ type StageEvent struct {
 	// for an inactive label).
 	VotedFor string
 
+	// VotedForRealName is the human-readable name of the candidate the
+	// voter chose, resolved from the active cohort at ballot-fan-out time.
+	// Empty when VotedFor == "" (discarded ballot) or when the chosen label
+	// is not in the active cohort. Lets the live stream render
+	// "voted for X (realname)" without the operator having to cross-
+	// reference verdict.json's anonymization map afterwards.
+	VotedForRealName string
+
 	// RejectedReason discriminates ballot-discard paths (one of the
 	// debate.BallotRejected* constants). Empty for round-expert events
 	// and for successful ballots. Lets the renderer distinguish the
@@ -123,19 +131,31 @@ func reportRoundExpert(rep Reporter, round int, ex LabeledExpert, r *RoundOutput
 // pointer-to-result pattern as reportRoundExpert so the defer reflects the
 // final outcome (success, discarded, or rate-limited). RunBallot normalizes
 // a nil BallotConfig.Reporter to NopReporter{} before fanning out, so this
-// callee can assume rep is always non-nil.
-func reportBallot(rep Reporter, ex LabeledExpert, b *Ballot, body []byte, resumed bool) {
+// callee can assume rep is always non-nil. candidates is the active cohort
+// passed through so the reporter can resolve b.VotedFor to a real name —
+// the renderer would otherwise have only the anonymized letter to show.
+func reportBallot(rep Reporter, ex LabeledExpert, candidates []LabeledExpert, b *Ballot, body []byte, resumed bool) {
+	var votedForRealName string
+	if b.VotedFor != "" {
+		for _, c := range candidates {
+			if c.Label == b.VotedFor {
+				votedForRealName = c.Role.Name
+				break
+			}
+		}
+	}
 	rep.OnStageDone(StageEvent{
-		Kind:           "ballot",
-		Round:          0,
-		Label:          ex.Label,
-		RealName:       ex.Role.Name,
-		Body:           body,
-		VotedFor:       b.VotedFor,
-		RejectedReason: b.RejectedReason,
-		LimitErr:       b.LimitErr,
-		Duration:       time.Duration(b.DurationSeconds * float64(time.Second)),
-		Retries:        b.Retries,
-		Resumed:        resumed,
+		Kind:             "ballot",
+		Round:            0,
+		Label:            ex.Label,
+		RealName:         ex.Role.Name,
+		Body:             body,
+		VotedFor:         b.VotedFor,
+		VotedForRealName: votedForRealName,
+		RejectedReason:   b.RejectedReason,
+		LimitErr:         b.LimitErr,
+		Duration:         time.Duration(b.DurationSeconds * float64(time.Second)),
+		Retries:          b.Retries,
+		Resumed:          resumed,
 	})
 }

--- a/pkg/debate/reporter.go
+++ b/pkg/debate/reporter.go
@@ -131,18 +131,15 @@ func reportRoundExpert(rep Reporter, round int, ex LabeledExpert, r *RoundOutput
 // pointer-to-result pattern as reportRoundExpert so the defer reflects the
 // final outcome (success, discarded, or rate-limited). RunBallot normalizes
 // a nil BallotConfig.Reporter to NopReporter{} before fanning out, so this
-// callee can assume rep is always non-nil. candidates is the active cohort
-// passed through so the reporter can resolve b.VotedFor to a real name —
-// the renderer would otherwise have only the anonymized letter to show.
-func reportBallot(rep Reporter, ex LabeledExpert, candidates []LabeledExpert, b *Ballot, body []byte, resumed bool) {
+// callee can assume rep is always non-nil. realNames is a precomputed
+// label->Role.Name map for the active cohort: built once in RunBallot
+// against the same defensive copy used to derive `active`, so reporting
+// resolves b.VotedFor in O(1) and never reads through the unsorted shared
+// cfg.Experts slice header.
+func reportBallot(rep Reporter, ex LabeledExpert, realNames map[string]string, b *Ballot, body []byte, resumed bool) {
 	var votedForRealName string
 	if b.VotedFor != "" {
-		for _, c := range candidates {
-			if c.Label == b.VotedFor {
-				votedForRealName = c.Role.Name
-				break
-			}
-		}
+		votedForRealName = realNames[b.VotedFor]
 	}
 	rep.OnStageDone(StageEvent{
 		Kind:             "ballot",

--- a/pkg/debate/reporter_test.go
+++ b/pkg/debate/reporter_test.go
@@ -143,7 +143,8 @@ func TestReporter_RunRound1_FailedFiresWithFailedState(t *testing.T) {
 
 // TestReporter_RunBallot_FiresPerVoter pins the ballot-stage analogue:
 // each voter produces one event with the parsed VotedFor reflecting the
-// final state.
+// final state. Also confirms VotedForRealName resolves against the active
+// cohort so the live stream can render "voted for A (realname)".
 func TestReporter_RunBallot_FiresPerVoter(t *testing.T) {
 	exec := &testExec{
 		name: testExecName,
@@ -151,13 +152,24 @@ func TestReporter_RunBallot_FiresPerVoter(t *testing.T) {
 			return "VOTE: A\n", nil
 		},
 	}
-	cfg, _ := setupBallotTest(t, "abcdef0012345678", exec)
+	cfg, labeled := setupBallotTest(t, "abcdef0012345678", exec)
 	rep := &recordingReporter{}
 	cfg.Reporter = rep
 
 	ballots, err := RunBallot(context.Background(), cfg, "q?", "agg")
 	if err != nil {
 		t.Fatalf("RunBallot: %v", err)
+	}
+
+	var wantRealNameForA string
+	for _, ex := range labeled {
+		if ex.Label == "A" {
+			wantRealNameForA = ex.Role.Name
+			break
+		}
+	}
+	if wantRealNameForA == "" {
+		t.Fatal("no expert with label A in fixture")
 	}
 
 	events := rep.snapshot()
@@ -176,6 +188,10 @@ func TestReporter_RunBallot_FiresPerVoter(t *testing.T) {
 		}
 		if ev.VotedFor != "A" {
 			t.Errorf("voter %s: VotedFor = %q, want A", b.VoterLabel, ev.VotedFor)
+		}
+		if ev.VotedForRealName != wantRealNameForA {
+			t.Errorf("voter %s: VotedForRealName = %q, want %q",
+				b.VoterLabel, ev.VotedForRealName, wantRealNameForA)
 		}
 		if string(ev.Body) != "VOTE: A\n" {
 			t.Errorf("voter %s: Body = %q, want VOTE: A\\n", b.VoterLabel, string(ev.Body))

--- a/pkg/debate/vote.go
+++ b/pkg/debate/vote.go
@@ -161,7 +161,7 @@ func runOneBallot(ctx context.Context, cfg BallotConfig, ex LabeledExpert, quest
 	result := Ballot{VoterLabel: ex.Label}
 	resumed := false
 	var reportBody []byte
-	defer func() { reportBallot(cfg.Reporter, ex, &result, reportBody, resumed) }()
+	defer func() { reportBallot(cfg.Reporter, ex, cfg.Experts, &result, reportBody, resumed) }()
 
 	votesDir := filepath.Join(cfg.Session.Path, "voting", "votes")
 	stdoutPath := filepath.Join(votesDir, ex.Label+".txt")

--- a/pkg/debate/vote.go
+++ b/pkg/debate/vote.go
@@ -136,8 +136,10 @@ func RunBallot(ctx context.Context, cfg BallotConfig, question, aggregateMD stri
 	experts := append([]LabeledExpert(nil), cfg.Experts...)
 	sort.Slice(experts, func(i, j int) bool { return experts[i].Label < experts[j].Label })
 	active := make(map[string]bool, len(experts))
+	realNames := make(map[string]string, len(experts))
 	for _, ex := range experts {
 		active[ex.Label] = true
+		realNames[ex.Label] = ex.Role.Name
 	}
 
 	ballots := make([]Ballot, len(experts))
@@ -146,7 +148,7 @@ func RunBallot(ctx context.Context, cfg BallotConfig, question, aggregateMD stri
 		wg.Add(1)
 		go func(i int, ex LabeledExpert) {
 			defer wg.Done()
-			ballots[i] = runOneBallot(ctx, cfg, ex, question, aggregateMD, active)
+			ballots[i] = runOneBallot(ctx, cfg, ex, question, aggregateMD, active, realNames)
 		}(i, ex)
 	}
 	wg.Wait()
@@ -157,11 +159,11 @@ func RunBallot(ctx context.Context, cfg BallotConfig, question, aggregateMD stri
 // Order of rejection: subprocess error → forgery → malformed output → vote
 // for inactive label. Each rejection yields VotedFor="" but is otherwise
 // silent — malformed ballots are a known D8 failure mode, not a run abort.
-func runOneBallot(ctx context.Context, cfg BallotConfig, ex LabeledExpert, question, aggregateMD string, active map[string]bool) Ballot {
+func runOneBallot(ctx context.Context, cfg BallotConfig, ex LabeledExpert, question, aggregateMD string, active map[string]bool, realNames map[string]string) Ballot {
 	result := Ballot{VoterLabel: ex.Label}
 	resumed := false
 	var reportBody []byte
-	defer func() { reportBallot(cfg.Reporter, ex, cfg.Experts, &result, reportBody, resumed) }()
+	defer func() { reportBallot(cfg.Reporter, ex, realNames, &result, reportBody, resumed) }()
 
 	votesDir := filepath.Join(cfg.Session.Path, "voting", "votes")
 	stdoutPath := filepath.Join(votesDir, ex.Label+".txt")


### PR DESCRIPTION
## Summary
- Resolves #14. The `--verbose` live stream now resolves the **candidate's** label as well as the voter's, rendering `ballot A (gemini_expert) voted for C (codex_expert) in 13.3s` (and the cache-reuse variant) so the operator no longer has to cross-reference `verdict.json.anonymization`.
- Plumbed the active cohort through `reportBallot` so `StageEvent` carries a new `VotedForRealName` field; the cmd/council renderer formats it via a `formatCandidate` helper that falls back to the bare label if a future event arrives without the real name.
- No change to `verdict.json` schema or non-verbose output. Reveal still happens strictly after voting completes — labels remain anonymous in every R1/R2 expert prompt.

## Test plan
- [x] `go test ./... -count=1`
- [x] `go vet ./...`
- [x] `cmd/council/reporter_test.go` updated: fresh + resumed cases assert the new `voted for X (realname)` format; new fallback case asserts a bare label when `VotedForRealName` is empty.
- [x] `pkg/debate/reporter_test.go` `TestReporter_RunBallot_FiresPerVoter` asserts `VotedForRealName` is populated by the fan-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)