### PR TITLE
ci: add gitleaks PII & secrets scan

### DIFF
--- a/.github/workflows/pii-scan.yml
+++ b/.github/workflows/pii-scan.yml
@@ -1,0 +1,13 @@
+name: PII & Secrets Scan
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  gitleaks:
+    uses: fitz123/claude-code-bot/.github/workflows/gitleaks-reusable.yml@main
+    secrets:
+      CONFIG_PAT: ${{ secrets.GITLEAKS_CONFIG_PAT }}


### PR DESCRIPTION
Adds the gitleaks scan that all other fitz123 public repos already have. Calls the shared reusable workflow at fitz123/claude-code-bot/.github/workflows/gitleaks-reusable.yml using a CONFIG_PAT secret to fetch the gitleaks config.