### PR TITLE
Clean published answer via fail-closed JSON extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A single opinion from a single LLM is noisy. Running the same question through m
 - Two-round debate (`rounds: 2`): R1 is blind (each expert answers independently), R2 is peer-aware (each expert sees every other expert's R1 output, anonymized).
 - Anonymization: experts are relabeled `A, B, C, …` derived from the session ID so the cohort is rotated per run.
 - Per-session nonce + forgery detection on LLM outputs — every structural fence the orchestrator emits carries a `[nonce-<16hex>] ===` suffix, and any matching line in a subprocess's stdout is rejected (ADR-0008 as amended by ADR-0011). Benign markdown dividers like `=== Section ===` pass the scan.
-- Voting stage: every active expert casts a ballot on the R2 aggregate; winner's R2 body is printed verbatim. A tie surfaces `output-A.md`, `output-B.md`, … and exits 2 (`no_consensus`).
+- Voting stage: every active expert casts a ballot on the R2 aggregate; the winner's published answer is printed to stdout (clean JSON-tail extraction by default — see below — with fail-closed fallback to the raw R2 body). A tie surfaces `output-A.md`, `output-B.md`, … and exits 2 (`no_consensus`).
 - `council resume` subcommand: finish an interrupted session without re-running completed stages.
 - `verdict.json.version` bumps to `2`; shape documented in [`docs/design/v2.md`](docs/design/v2.md).
 - Published answer is a clean extraction from the winner's R2 JSON tail: every R2 ends with a fenced JSON block containing a peer-free `answer`, and that string lands in `output.md` and `verdict.answer`. Raw R2 with full peer-engaged reasoning stays in `rounds/r2/<label>.txt` unchanged. Extraction is fail-closed — missing or malformed JSON falls back to writing the raw R2 (today's pre-extraction behavior). The outcome is recorded in `verdict.json.answer_extraction`. See [ADR-0014](docs/adr/0014-json-extraction-published-answer.md).
@@ -87,7 +87,7 @@ Pipe a long question via stdin (use `-` as the positional argument):
 cat question.md | council -
 ```
 
-Both forms run the question through every expert in the active profile (R1 blind → R2 peer-aware), then every surviving expert votes on the best R2 answer. The winner's R2 text is printed to stdout verbatim; on a tie, each tied expert's answer lands in `output-<label>.md` and the exit code is 2. Transcripts and artifacts always land in `./.council/sessions/<id>/`.
+Both forms run the question through every expert in the active profile (R1 blind → R2 peer-aware), then every surviving expert votes on the best R2 answer. The winner's published answer is printed to stdout — by default this is the clean JSON-tail `answer` extracted from the winner's R2 (ADR-0014); if extraction fails, the raw R2 body is printed verbatim instead. On a tie, each tied expert's answer lands in `output-<label>.md` and the exit code is 2. Transcripts and artifacts always land in `./.council/sessions/<id>/`.
 
 Resume an interrupted run:
 
@@ -191,6 +191,8 @@ Per-stage events arrive in completion order (whoever finishes first appears firs
 - `round 2 expert X (name) carried R1 body forward (R2 failed)` — R2 subprocess failed; R1 body was carried forward (variants: `R2 rate-limited: <pattern>` for vendor rate limits, `reused carried R1 body from cache` on resume).
 - `round N expert X (name) FAILED in Ts` — subprocess error after retries (variant: `FAILED in Ts: rate-limited (<pattern>)`).
 - `ballot X (name) voted for Y in Ts` / `discarded (rate-limited)` / `discarded (malformed)`.
+- `extracted clean answer from winner X (name): N chars` — JSON-tail extraction succeeded (ADR-0014); `output.md` and `verdict.answer` carry the extracted answer. Only fires on the unique-winner path.
+- `extraction fell back to raw R2 from winner X (name): <reason>` — fail-closed fallback; reason ∈ {`no JSON block`, `malformed JSON`, `answer field missing or wrong type`, `answer field empty`}. `output.md` is the raw R2 verbatim.
 
 The closing `=== verdict (winner: X — name, A/N votes) ===` block carries only the header — the answer body lives on stdout to avoid duplication when both streams render to the same terminal. On a tie, the block reads `=== verdict (no consensus — tied: A, C) ===` (no body).
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A single opinion from a single LLM is noisy. Running the same question through m
 - Voting stage: every active expert casts a ballot on the R2 aggregate; the winner's published answer is printed to stdout (clean JSON-tail extraction by default — see below — with fail-closed fallback to the raw R2 body). A tie surfaces `output-A.md`, `output-B.md`, … and exits 2 (`no_consensus`).
 - `council resume` subcommand: finish an interrupted session without re-running completed stages.
 - `verdict.json.version` bumps to `2`; shape documented in [`docs/design/v2.md`](docs/design/v2.md).
-- Published answer is a clean extraction from the winner's R2 JSON tail: every R2 ends with a fenced JSON block containing a peer-free `answer`, and that string lands in `output.md` and `verdict.answer`. Raw R2 with full peer-engaged reasoning stays in `rounds/r2/<label>.txt` unchanged. Extraction is fail-closed — missing or malformed JSON falls back to writing the raw R2 (today's pre-extraction behavior). The outcome is recorded in `verdict.json.answer_extraction`. See [ADR-0014](docs/adr/0014-json-extraction-published-answer.md).
+- Published answer is a clean extraction from the winner's R2 JSON tail: every R2 ends with a fenced JSON block containing a peer-free `answer`, and that string lands in `output.md` and `verdict.answer`. Raw R2 with full peer-engaged reasoning stays in `rounds/2/experts/<label>/output.md` unchanged. Extraction is fail-closed — missing or malformed JSON falls back to writing the raw R2 (today's pre-extraction behavior). The outcome is recorded in `verdict.json.answer_extraction`. See [ADR-0014](docs/adr/0014-json-extraction-published-answer.md).
 
 ## Web tools
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A single opinion from a single LLM is noisy. Running the same question through m
 - Voting stage: every active expert casts a ballot on the R2 aggregate; winner's R2 body is printed verbatim. A tie surfaces `output-A.md`, `output-B.md`, … and exits 2 (`no_consensus`).
 - `council resume` subcommand: finish an interrupted session without re-running completed stages.
 - `verdict.json.version` bumps to `2`; shape documented in [`docs/design/v2.md`](docs/design/v2.md).
+- Published answer is a clean extraction from the winner's R2 JSON tail: every R2 ends with a fenced JSON block containing a peer-free `answer`, and that string lands in `output.md` and `verdict.answer`. Raw R2 with full peer-engaged reasoning stays in `rounds/r2/<label>.txt` unchanged. Extraction is fail-closed — missing or malformed JSON falls back to writing the raw R2 (today's pre-extraction behavior). The outcome is recorded in `verdict.json.answer_extraction`. See [ADR-0014](docs/adr/0014-json-extraction-published-answer.md).
 
 ## Web tools
 
@@ -232,7 +233,7 @@ A `council gc` subcommand is on the roadmap.
 - [`docs/design/v2-web-tools.md`](docs/design/v2-web-tools.md) — web-tools supplement (R1/R2 tools, token + latency envelope, audit recipe).
 - [`docs/design/v3-multi-cli.md`](docs/design/v3-multi-cli.md) — multi-CLI supplement (codex + gemini executors, `council init`, exit code 6, rate-limit policy).
 - [`docs/design/v1.md`](docs/design/v1.md) — MVP spec (superseded by v2 for the run loop; still useful for file-artifact and CLI-shape invariants).
-- [`docs/adr/`](docs/adr/) — architectural decision records (0008 for debate rounds + injection, 0010 for expert web tools, 0011 for nonce-every-fence, 0012 for multi-CLI executors, 0013 for runner-side rate-limit retry removal).
+- [`docs/adr/`](docs/adr/) — architectural decision records (0008 for debate rounds + injection, 0010 for expert web tools, 0011 for nonce-every-fence, 0012 for multi-CLI executors, 0013 for runner-side rate-limit retry removal, 0014 for JSON-tail extraction of the published answer).
 - [`docs/architect-review.md`](docs/architect-review.md) — systems-architect methodology review of the spec.
 
 ## License

--- a/cmd/council/reporter.go
+++ b/cmd/council/reporter.go
@@ -43,6 +43,8 @@ func (r *stderrReporter) OnStageDone(e debate.StageEvent) {
 		r.renderRoundExpert(e)
 	case "ballot":
 		r.renderBallot(e)
+	case "extraction":
+		r.renderExtraction(e)
 	default:
 		// StageEvent.Kind is intentionally additive — a future stage type
 		// could land in pkg/debate without the renderer growing an arm
@@ -127,6 +129,44 @@ func (r *stderrReporter) renderBallot(e debate.StageEvent) {
 	}
 	if e.VotedFor == "" {
 		fmt.Fprintln(r.w, "(no vote — discarded)")
+	}
+}
+
+// renderExtraction surfaces the JSON-tail extraction outcome (ADR-0014)
+// for the unique-winner path. On ExtractOK the live stream reports the
+// byte length of the published answer; on any fallback it reports a
+// human-readable reason so the operator can spot vendor compliance gaps
+// without re-reading verdict.json. Body carries the bytes that landed in
+// output.md, so len(e.Body) is the published-answer length on the OK
+// path and the raw-R2 length on the fallback path.
+func (r *stderrReporter) renderExtraction(e debate.StageEvent) {
+	ts := nowStamp()
+	winner := formatCandidate(e.Label, e.RealName)
+	if e.ExtractStatus == debate.ExtractOK {
+		fmt.Fprintf(r.w, "[%s] extracted clean answer from winner %s: %d chars\n",
+			ts, winner, len(e.Body))
+		return
+	}
+	fmt.Fprintf(r.w, "[%s] extraction fell back to raw R2 from winner %s: %s\n",
+		ts, winner, extractFallbackReason(e.ExtractStatus))
+}
+
+// extractFallbackReason maps an ExtractStatus to the human-readable
+// reason shown after "fell back to raw R2 ... :" in the live stream. The
+// renderer only reaches this map on a non-OK status, so ExtractOK is
+// intentionally absent — the rendering branch above handles it.
+func extractFallbackReason(s debate.ExtractStatus) string {
+	switch s {
+	case debate.ExtractNoJSONBlock:
+		return "no JSON block"
+	case debate.ExtractInvalidJSON:
+		return "malformed JSON"
+	case debate.ExtractMissingAnswer:
+		return "answer field missing or wrong type"
+	case debate.ExtractEmptyAnswer:
+		return "answer field empty"
+	default:
+		return "unknown"
 	}
 }
 

--- a/cmd/council/reporter_test.go
+++ b/cmd/council/reporter_test.go
@@ -269,6 +269,78 @@ func TestStderrReporter_Render(t *testing.T) {
 			},
 			mustOmit: []string{"voted for", "rate-limited"},
 		},
+		{
+			name: "extraction ok",
+			ev: debate.StageEvent{
+				Kind: "extraction", Label: "B", RealName: "claude_expert",
+				Body:          []byte("Clean standalone answer.\n"),
+				ExtractStatus: debate.ExtractOK,
+			},
+			mustContain: []string{
+				"[12:00:00] extracted clean answer from winner B (claude_expert): 25 chars",
+			},
+			mustOmit: []string{"fell back", "no JSON", "malformed"},
+		},
+		{
+			name: "extraction fallback no_json",
+			ev: debate.StageEvent{
+				Kind: "extraction", Label: "A", RealName: "codex_expert",
+				Body:          []byte("raw R2 body"),
+				ExtractStatus: debate.ExtractNoJSONBlock,
+			},
+			mustContain: []string{
+				"[12:00:00] extraction fell back to raw R2 from winner A (codex_expert): no JSON block",
+			},
+			mustOmit: []string{"extracted clean", "chars"},
+		},
+		{
+			name: "extraction fallback invalid_json",
+			ev: debate.StageEvent{
+				Kind: "extraction", Label: "C", RealName: "gemini_expert",
+				Body:          []byte("raw R2 body"),
+				ExtractStatus: debate.ExtractInvalidJSON,
+			},
+			mustContain: []string{
+				"extraction fell back to raw R2 from winner C (gemini_expert): malformed JSON",
+			},
+			mustOmit: []string{"extracted clean"},
+		},
+		{
+			name: "extraction fallback missing_answer",
+			ev: debate.StageEvent{
+				Kind: "extraction", Label: "B", RealName: "haiku",
+				Body:          []byte("raw R2 body"),
+				ExtractStatus: debate.ExtractMissingAnswer,
+			},
+			mustContain: []string{
+				"extraction fell back to raw R2 from winner B (haiku): answer field missing or wrong type",
+			},
+			mustOmit: []string{"extracted clean"},
+		},
+		{
+			name: "extraction fallback empty_answer",
+			ev: debate.StageEvent{
+				Kind: "extraction", Label: "A", RealName: "codex_expert",
+				Body:          []byte("raw R2 body"),
+				ExtractStatus: debate.ExtractEmptyAnswer,
+			},
+			mustContain: []string{
+				"extraction fell back to raw R2 from winner A (codex_expert): answer field empty",
+			},
+			mustOmit: []string{"extracted clean"},
+		},
+		{
+			name: "extraction ok missing real name falls back to bare label",
+			ev: debate.StageEvent{
+				Kind: "extraction", Label: "B",
+				Body:          []byte("answer."),
+				ExtractStatus: debate.ExtractOK,
+			},
+			mustContain: []string{
+				"[12:00:00] extracted clean answer from winner B: 7 chars",
+			},
+			mustOmit: []string{"winner B (", "winner B ()"},
+		},
 	}
 
 	for _, c := range cases {

--- a/defaults/prompts/peer-aware.md
+++ b/defaults/prompts/peer-aware.md
@@ -34,3 +34,25 @@ Sycophancy resistance (hard rules):
 Format: 3-8 sentences of your refined answer, with inline URL citations
 where you verified (or refuted) a claim. No meta-commentary about the
 debate process itself.
+
+Output discipline:
+- Your response is in two halves separated by a blank line.
+- First half: your peer-engaged refinement above. Peer references and
+  meta-references to other experts are allowed here — voters use this
+  prose to evaluate engagement and verification.
+- Second half MUST be the LAST content in the response, after a blank
+  line: a fenced JSON code block with this exact shape:
+
+  ```json
+  {
+    "answer": "<3-8 sentence clean standalone answer to the original question; no references to peers; preserve URL citations inline>",
+    "citations": ["<url>", "<url>"]
+  }
+  ```
+
+The JSON block is what gets published as the final answer. The "no
+meta-commentary" rule applies specifically to the JSON `answer` field:
+it must read as a self-contained answer to the original question, with
+no "Expert A said…" or "as my peer noted…" phrasing. The JSON block
+must be the last content in your response — nothing after the closing
+fence.

--- a/docs/adr/0014-json-extraction-published-answer.md
+++ b/docs/adr/0014-json-extraction-published-answer.md
@@ -1,0 +1,81 @@
+# ADR-0014: JSON-Tail Extraction for the Published Answer
+
+**Status:** Accepted
+**Date:** 2026-04-28
+**Extends:** ADR-0006 (synthesis-only judge), ADR-0008 (debate rounds — winner R2 verbatim)
+**Cites:** Issue [#16](https://github.com/fitz123/council/issues/16); council session `2026-04-27T21-24-13Z-pleasantly-above-maggot`
+
+## Context
+
+ADR-0006 (as reshaped by ADR-0008) removed the judge: voting picks a winner, and the winner's R2 body is the published answer verbatim. R2 is peer-aware — every expert reads every other expert's R1 and is instructed to engage with it. The result: clean reasoning, but the published answer often carries debate meta-commentary referring to other experts ("Эксперт A корректно указывает...", "Эксперт B справедливо вводит развилку..."). This is correct *for voters* (they need the engagement to evaluate the answer) and wrong *for the published artifact* (a reader of `output.md` did not see Experts A/B/C and has no referent for those names).
+
+The orchestrator already preserves both halves of the artifact: every R2 body lands verbatim in `rounds/r2/<label>.txt`. What's missing is a clean, peer-free version for `output.md` and `verdict.answer`.
+
+## Decision
+
+Every R2 response must end with a fenced JSON code block carrying a clean `answer` and optional `citations[]`:
+
+```json
+{
+  "answer": "<3-8 sentence clean standalone answer; no peer references; preserve URL citations inline>",
+  "citations": ["<url>", "..."]
+}
+```
+
+The orchestrator extracts the winner's `answer` field and writes it to `output.md` and `verdict.answer`. Raw R2 stays in `rounds/r2/<label>.txt` unchanged.
+
+**Fail-closed:** if the JSON block is missing, malformed, lacks the `answer` key, or `answer` is empty/non-string, fall back to writing the raw R2 body. The fallback path is exactly today's behavior — there is no regression risk versus the pre-extraction baseline.
+
+The extraction outcome is recorded in `verdict.json.answer_extraction.{status, winner_label}`, where `status ∈ {ok, fallback_no_json, fallback_invalid_json, fallback_missing_answer, fallback_empty_answer}`. This makes parse-success rate a queryable post-hoc metric.
+
+The verbose stream emits a one-line event per session: either `extracted clean answer from winner B (claude_expert): N chars` or `extraction fell back to raw R2 from winner B (claude_expert): <reason>`.
+
+## Alternatives considered
+
+**a) Winner-rewrite pass (council's headline pick — "B + validation").** A second LLM call rewrites the winner's R2 into a clean answer; an optional third call validates fidelity. Rejected as the primary path: 2 extra LLM calls per session (cost + latency on critical path), regenerates the answer (drift risk versus what voters read), introduces a validator-honesty problem. Kept as the documented fallback if extraction parse rates prove unreliable in production.
+
+**b) Text-marker section format (e.g., `--- ANSWER ---` line in the response).** Rejected: free-text markers are weaker than JSON across vendors. CLIs strip whitespace, reformat headings, and occasionally rewrite literal markers; JSON is more enforceable because every vendor is heavily JSON-trained.
+
+**c) Mechanical regex strip of peer references.** Rejected: the meta-commentary surface is open-ended ("Expert A...", "коллега Б...", "the previous expert"). A regex that catches them all also catches benign mentions; one that doesn't catches nothing useful. Generative output requires generative cleanup.
+
+**d) Strip the JSON block from candidate text shown to voters.** Deferred. Current behavior keeps the JSON visible in candidates; verbosity-bias literature is unresolved and we should not change voter inputs on speculation. Revisit only if vote-quality regressions are observed.
+
+**e) Apply extraction in the tied-candidates branch.** Out of scope. Ties are rare; surfacing multiple `output-<label>.md` files already works. Add later if needed.
+
+## Consequences
+
+- `output.md` and `verdict.answer` become clean, peer-free prose on the happy path.
+- `rounds/r2/<label>.txt` is unchanged — full R2 with engagement reasoning is preserved for audit.
+- Worst case (every fallback path) is exactly today's behavior: raw R2 published.
+- The R2 prompt becomes more demanding (the council's "instruction overflow" critique partially applies). Fail-closed → raw R2 mitigates the downside.
+- One additive field in `verdict.json`. No `version` bump (consumers ignore unknown fields).
+- New verbose-stream event line per session.
+
+## Compliance
+
+| # | Fitness | Concrete check |
+|---|---------|----------------|
+| F36 | Extraction outcome recorded on every session that runs `SelectOutput` | `jq -e '.answer_extraction.status == "ok" or (.answer_extraction.status \| startswith("fallback_"))' verdict.json` returns true |
+| F37 | Raw R2 preserved regardless of extraction outcome | `rounds/r2/<winner>.txt` byte-for-byte equals the winner subprocess body, even when `output.md` is the extracted answer |
+| F38 | Fail-closed on malformed JSON | Hand-crafted R2 with malformed JSON tail → `output.md` contains the raw R2; `answer_extraction.status == "fallback_invalid_json"`; no panic |
+| F39 | Fenced-block requirement enforced | R2 ending in raw `{...}` without code fence → `ExtractNoJSONBlock`; raw R2 published |
+| F40 | Last fenced block wins | R2 with two `json` fences → extracts the last; voters' candidates unaffected |
+
+## Research
+
+- Issue [#16 — Cleaning the published answer](https://github.com/fitz123/council/issues/16): full design discussion, including the council's recommendation and the dissenting position that became this plan.
+- Council session `.council/sessions/2026-04-27T21-24-13Z-pleasantly-above-maggot/`: 2-1 verdict for "B + validation", with structured-extraction promoted by 2/3 R2 responses as the stronger third option. The choice to ship structured-extraction first (instead of B + validation) is documented in the plan's Overview: zero extra LLM calls, zero added latency on critical path, no drift risk between what voters read and what gets published, and a fail-closed worst case.
+
+## Post-completion fitness function
+
+After 5–10 real sessions across mixed question types:
+
+```
+jq '.answer_extraction.status' .council/sessions/*/verdict.json | sort | uniq -c
+```
+
+Target: `ok` ≥ 90% across all three vendors (Claude / Codex / Gemini). If any single vendor is below 90%, open a follow-up to either (a) tune the prompt for that vendor or (b) implement alternative (a) — the rewrite pass — as the salvage path.
+
+## Status
+
+Accepted. Implementation landed in branch `clean-published-answer-json-extraction` (Tasks 1–7 of `docs/plans/2026-04-28-clean-published-answer-json-extraction.md`). Empirical observation period documented in the plan's Post-Completion section.

--- a/docs/adr/0014-json-extraction-published-answer.md
+++ b/docs/adr/0014-json-extraction-published-answer.md
@@ -9,7 +9,7 @@
 
 ADR-0006 (as reshaped by ADR-0008) removed the judge: voting picks a winner, and the winner's R2 body is the published answer verbatim. R2 is peer-aware — every expert reads every other expert's R1 and is instructed to engage with it. The result: clean reasoning, but the published answer often carries debate meta-commentary referring to other experts ("Эксперт A корректно указывает...", "Эксперт B справедливо вводит развилку..."). This is correct *for voters* (they need the engagement to evaluate the answer) and wrong *for the published artifact* (a reader of `output.md` did not see Experts A/B/C and has no referent for those names).
 
-The orchestrator already preserves both halves of the artifact: every R2 body lands verbatim in `rounds/r2/<label>.txt`. What's missing is a clean, peer-free version for `output.md` and `verdict.answer`.
+The orchestrator already preserves both halves of the artifact: every R2 body lands verbatim in `rounds/2/experts/<label>/output.md`. What's missing is a clean, peer-free version for the session-root `output.md` and `verdict.answer`.
 
 ## Decision
 
@@ -22,7 +22,7 @@ Every R2 response must end with a fenced JSON code block carrying a clean `answe
 }
 ```
 
-The orchestrator extracts the winner's `answer` field and writes it to `output.md` and `verdict.answer`. Raw R2 stays in `rounds/r2/<label>.txt` unchanged.
+The orchestrator extracts the winner's `answer` field and writes it to `output.md` and `verdict.answer`. Raw R2 stays in `rounds/2/experts/<label>/output.md` unchanged.
 
 **Fail-closed:** if the JSON block is missing, malformed, lacks the `answer` key, or `answer` is empty/non-string, fall back to writing the raw R2 body. The fallback path is exactly today's behavior — there is no regression risk versus the pre-extraction baseline.
 
@@ -45,7 +45,7 @@ The verbose stream emits a one-line event per session: either `extracted clean a
 ## Consequences
 
 - `output.md` and `verdict.answer` become clean, peer-free prose on the happy path.
-- `rounds/r2/<label>.txt` is unchanged — full R2 with engagement reasoning is preserved for audit.
+- `rounds/2/experts/<label>/output.md` is unchanged — full R2 with engagement reasoning is preserved for audit.
 - Worst case (every fallback path) is exactly today's behavior: raw R2 published.
 - The R2 prompt becomes more demanding (the council's "instruction overflow" critique partially applies). Fail-closed → raw R2 mitigates the downside.
 - One additive field in `verdict.json`. No `version` bump (consumers ignore unknown fields).
@@ -56,7 +56,7 @@ The verbose stream emits a one-line event per session: either `extracted clean a
 | # | Fitness | Concrete check |
 |---|---------|----------------|
 | F36 | Extraction outcome recorded on every session that runs `SelectOutput` | `jq -e '.answer_extraction.status == "ok" or (.answer_extraction.status \| startswith("fallback_"))' verdict.json` returns true |
-| F37 | Raw R2 preserved regardless of extraction outcome | `rounds/r2/<winner>.txt` byte-for-byte equals the winner subprocess body, even when `output.md` is the extracted answer |
+| F37 | Raw R2 preserved regardless of extraction outcome | `rounds/2/experts/<winner>/output.md` byte-for-byte equals the winner subprocess body, even when the session-root `output.md` is the extracted answer |
 | F38 | Fail-closed on malformed JSON | Hand-crafted R2 with malformed JSON tail → `output.md` contains the raw R2; `answer_extraction.status == "fallback_invalid_json"`; no panic |
 | F39 | Fenced-block requirement enforced | R2 ending in raw `{...}` without code fence → `ExtractNoJSONBlock`; raw R2 published |
 | F40 | Last fenced block wins | R2 with two `json` fences → extracts the last; voters' candidates unaffected |

--- a/docs/design/v2.md
+++ b/docs/design/v2.md
@@ -23,6 +23,12 @@ round where they see each other's reasoning (anonymized), then vote on
 whose final answer is best. The winner's answer is returned verbatim.
 No judge, no synthesis, no polish.
 
+> **Amended by ADR-0014:** the winner's published `output.md` is now the
+> JSON-tail `answer` extracted from the winner's R2, with a fail-closed
+> fallback to the raw R2 body when the JSON tail is missing or malformed.
+> The raw R2 reasoning is always preserved at `rounds/r2/<label>.txt` for
+> audit. See `docs/adr/0014-json-extraction-published-answer.md`.
+
 ### 1.3 Why now
 
 Empirical research on multi-agent LLM systems (see §6 Research Map) shows
@@ -771,7 +777,11 @@ Empty folders and final sessions are skipped.
 
 **What:** v2 has no judge subprocess, no synthesis step, no polish
 step. The winning expert's R2 `output.md` is copied verbatim to
-`output.md` at session root.
+`output.md` at session root. *(ADR-0014 amends this: the published
+`output.md` is the JSON-tail `answer` extracted from the winner's R2
+when extraction succeeds, with a fail-closed fallback to the verbatim
+R2 body otherwise; the raw R2 is always preserved at
+`rounds/r2/<label>.txt`.)*
 
 **Why:** A single judge creates a single point of model bias. The
 judge model's preferences — length bias, position bias, self-

--- a/docs/design/v2.md
+++ b/docs/design/v2.md
@@ -305,7 +305,7 @@ voting/tally.json:
 **Tally rule (general form):** unique max wins. If multiple labels are tied at the max vote count (including the degenerate all-zero case from all-malformed ballots) → `tied_candidates = [those labels]`. See D8 for the formal spec.
 
 **Output selection:**
-- Unique winner (B) → copy `rounds/2/experts/B/output.md` to session root `output.md`. Exit 0.
+- Unique winner (B) → publish the winner's answer to session root `output.md`. Exit 0. *(ADR-0014: the published `output.md` is the JSON-tail `answer` extracted from `rounds/2/experts/B/output.md`; on extraction failure the orchestrator falls back to the verbatim R2 body. The raw R2 reasoning is always preserved at `rounds/2/experts/B/output.md`.)*
 - If it had been a tie (e.g., 1-1-1 at N=3 or 1-1 at N=2 reduced cohort): copy each tied label's R2 output to `output-A.md` / `output-B.md` / etc. Exit 2 `no_consensus`.
 
 ### 3.9 Verdict + finality
@@ -583,7 +583,7 @@ identifying their own answer; writing-style leak is a known limitation
 
 Let `S` = the set of active candidate labels (surviving experts after the final round; `|S|` equals post-R2 cohort size). Let `votes: map[label → int]` be the tally of valid ballots over labels in `S`. Malformed ballots and ballots for labels not in `S` are discarded (do not count toward any candidate).
 
-- **Unique max → winner.** If exactly one label has the highest vote count, that label wins. Its R2 output is copied verbatim to `output.md` at session root. Exit 0.
+- **Unique max → winner.** If exactly one label has the highest vote count, that label wins. Its answer is published to `output.md` at session root. Exit 0. *(ADR-0014 amends this: `output.md` receives the JSON-tail `answer` extracted from the winner's R2, with a fail-closed fallback to the verbatim R2 body when extraction fails; the raw R2 is always preserved at `rounds/2/experts/<winner>/output.md`.)*
 - **Multiple labels tied at max → no consensus.** Every label tied at the maximum vote count (including the degenerate case of all-tied-at-one or all-at-zero when every ballot was malformed) is a tied candidate. Each tied label's R2 output is copied to `output-<label>.md` at session root. `verdict.json.voting.tied_candidates` lists every tied label. Exit 2 `no_consensus`. See D16.
 
 **Example outcomes at N=3 full cohort:**

--- a/docs/design/v2.md
+++ b/docs/design/v2.md
@@ -26,8 +26,9 @@ No judge, no synthesis, no polish.
 > **Amended by ADR-0014:** the winner's published `output.md` is now the
 > JSON-tail `answer` extracted from the winner's R2, with a fail-closed
 > fallback to the raw R2 body when the JSON tail is missing or malformed.
-> The raw R2 reasoning is always preserved at `rounds/r2/<label>.txt` for
-> audit. See `docs/adr/0014-json-extraction-published-answer.md`.
+> The raw R2 reasoning is always preserved at
+> `rounds/2/experts/<label>/output.md` for audit. See
+> `docs/adr/0014-json-extraction-published-answer.md`.
 
 ### 1.3 Why now
 
@@ -781,7 +782,7 @@ step. The winning expert's R2 `output.md` is copied verbatim to
 `output.md` is the JSON-tail `answer` extracted from the winner's R2
 when extraction succeeds, with a fail-closed fallback to the verbatim
 R2 body otherwise; the raw R2 is always preserved at
-`rounds/r2/<label>.txt`.)*
+`rounds/2/experts/<label>/output.md`.)*
 
 **Why:** A single judge creates a single point of model bias. The
 judge model's preferences — length bias, position bias, self-

--- a/docs/plans/2026-04-28-clean-published-answer-json-extraction.md
+++ b/docs/plans/2026-04-28-clean-published-answer-json-extraction.md
@@ -4,7 +4,7 @@
 
 The published answer in `verdict.answer` and `output.md` currently contains debate meta-commentary referring to other experts ("Эксперт A корректно указывает...", "Эксперт B справедливо вводит развилку..."). Per ADR-0006/0008, the winner's R2 text is returned verbatim because voting replaced the judge — there is no synthesis stage.
 
-This plan introduces a **fail-closed JSON extraction** approach: every R2 response must end with a fenced JSON block containing a clean `answer` and `citations[]`. The orchestrator extracts the winner's `answer` field and writes that to `output.md` and `verdict.answer`. Raw R2 stays in `rounds/r2/<label>.txt` unchanged.
+This plan introduces a **fail-closed JSON extraction** approach: every R2 response must end with a fenced JSON block containing a clean `answer` and `citations[]`. The orchestrator extracts the winner's `answer` field and writes that to `output.md` and `verdict.answer`. Raw R2 stays in `rounds/2/experts/<label>/output.md` unchanged.
 
 When extraction fails (no JSON block, malformed JSON, missing/empty `answer`), the orchestrator falls back to writing the raw R2 — strictly today's behavior, no regression.
 
@@ -56,7 +56,7 @@ This is "Option A done right" (per the council session 2026-04-27T21-24-13Z-plea
 
 - **Unit tests:** extractor parser (table-driven), SelectOutput integration (success + each fallback path), verdict-shape assertions.
 - **No e2e:** project does not have UI e2e infrastructure.
-- **Manual smoke:** run `council` against a known question after implementation; eyeball that `output.md` is clean and that `rounds/r2/<winner>.txt` still has the full debate text.
+- **Manual smoke:** run `council` against a known question after implementation; eyeball that `output.md` is clean and that `rounds/2/experts/<winner>/output.md` still has the full debate text.
 
 ## Progress Tracking
 
@@ -137,7 +137,7 @@ This is "Option A done right" (per the council session 2026-04-27T21-24-13Z-plea
 - [x] verify all requirements from Overview are implemented:
   - Winner's clean answer becomes `verdict.answer` and `output.md` when JSON extraction succeeds.
   - Raw R2 fallback writes the same content as today on every failure path.
-  - `rounds/r2/<label>.txt` is unchanged for every expert (always full body).
+  - `rounds/2/experts/<label>/output.md` is unchanged for every expert (always full body).
   - `verdict.json.answer_extraction` records the outcome.
 - [x] verify edge cases are handled (each `ExtractStatus` value has at least one test).
 - [x] run full test suite: `go test ./...` — all green.
@@ -147,7 +147,7 @@ This is "Option A done right" (per the council session 2026-04-27T21-24-13Z-plea
 
 ### Task 7: Update documentation
 
-- [x] update `README.md`: under "What's new in v2" (or wherever post-v2 changes are listed), add a one-paragraph note that the published answer is now a clean extraction from the winner's R2 JSON tail, with raw R2 preserved in `rounds/r2/`.
+- [x] update `README.md`: under "What's new in v2" (or wherever post-v2 changes are listed), add a one-paragraph note that the published answer is now a clean extraction from the winner's R2 JSON tail, with raw R2 preserved in `rounds/2/experts/<label>/output.md`.
 - [x] add ADR `docs/adr/0014-json-extraction-published-answer.md` following the existing ADR template (Status, Context, Alternatives, Decision, Consequences, Compliance, Research, Supersedes/Extends).
   - Status: Accepted (cite session 2026-04-27T21-24-13Z-pleasantly-above-maggot + issue #16).
   - Decision: JSON-tail extraction with fail-closed → raw R2 fallback.
@@ -237,7 +237,7 @@ The "No meta-commentary about the debate process itself" line stays — it now a
 
 **Manual verification:**
 - Eyeball `output.md` of 3–5 sessions to confirm it reads as a clean answer to the original question with no "Expert A/B/C" references.
-- Compare `output.md` vs. `rounds/r2/<winner>.txt` on a few sessions to confirm no information loss in the answer field.
+- Compare `output.md` vs. `rounds/2/experts/<winner>/output.md` on a few sessions to confirm no information loss in the answer field.
 
 **Follow-up work (potential, not in this plan):**
 - Apply the same extraction in the tied-candidates path (multi-winner ties) — out of scope here, separate issue.

--- a/docs/plans/2026-04-28-clean-published-answer-json-extraction.md
+++ b/docs/plans/2026-04-28-clean-published-answer-json-extraction.md
@@ -147,14 +147,14 @@ This is "Option A done right" (per the council session 2026-04-27T21-24-13Z-plea
 
 ### Task 7: Update documentation
 
-- [ ] update `README.md`: under "What's new in v2" (or wherever post-v2 changes are listed), add a one-paragraph note that the published answer is now a clean extraction from the winner's R2 JSON tail, with raw R2 preserved in `rounds/r2/`.
-- [ ] add ADR `docs/adr/0014-json-extraction-published-answer.md` following the existing ADR template (Status, Context, Alternatives, Decision, Consequences, Compliance, Research, Supersedes/Extends).
+- [x] update `README.md`: under "What's new in v2" (or wherever post-v2 changes are listed), add a one-paragraph note that the published answer is now a clean extraction from the winner's R2 JSON tail, with raw R2 preserved in `rounds/r2/`.
+- [x] add ADR `docs/adr/0014-json-extraction-published-answer.md` following the existing ADR template (Status, Context, Alternatives, Decision, Consequences, Compliance, Research, Supersedes/Extends).
   - Status: Accepted (cite session 2026-04-27T21-24-13Z-pleasantly-above-maggot + issue #16).
   - Decision: JSON-tail extraction with fail-closed → raw R2 fallback.
   - Alternatives evaluated: B + validation pass (council's headline), text-marker section format, mechanical regex strip.
   - Compliance fitness function: `jq -e '.answer_extraction.status == "ok" or (.answer_extraction.status | startswith("fallback_"))' verdict.json` returns true on every session.
-- [ ] reference issue #16 and the council session in the ADR's "Research" section.
-- [ ] no `verdict.json.version` bump (additive change; consumers ignore unknown fields).
+- [x] reference issue #16 and the council session in the ADR's "Research" section.
+- [x] no `verdict.json.version` bump (additive change; consumers ignore unknown fields).
 
 *Note: ralphex automatically moves completed plans to `docs/plans/completed/`.*
 

--- a/docs/plans/2026-04-28-clean-published-answer-json-extraction.md
+++ b/docs/plans/2026-04-28-clean-published-answer-json-extraction.md
@@ -1,0 +1,244 @@
+# Clean Published Answer — JSON Extraction from R2
+
+## Overview
+
+The published answer in `verdict.answer` and `output.md` currently contains debate meta-commentary referring to other experts ("Эксперт A корректно указывает...", "Эксперт B справедливо вводит развилку..."). Per ADR-0006/0008, the winner's R2 text is returned verbatim because voting replaced the judge — there is no synthesis stage.
+
+This plan introduces a **fail-closed JSON extraction** approach: every R2 response must end with a fenced JSON block containing a clean `answer` and `citations[]`. The orchestrator extracts the winner's `answer` field and writes that to `output.md` and `verdict.answer`. Raw R2 stays in `rounds/r2/<label>.txt` unchanged.
+
+When extraction fails (no JSON block, malformed JSON, missing/empty `answer`), the orchestrator falls back to writing the raw R2 — strictly today's behavior, no regression.
+
+This is "Option A done right" (per the council session 2026-04-27T21-24-13Z-pleasantly-above-maggot in issue #16): JSON is materially more reliable than the original `--- ANSWER ---` text marker because every vendor CLI is heavily JSON-trained, and the failure mode is fail-closed instead of fail-open.
+
+**Why JSON extraction over winner-rewrite (the council's headline pick):**
+- Zero extra LLM calls (vs. 2 extra calls for B + validation pass).
+- Zero added latency on critical path.
+- No drift risk — extraction does not regenerate; the winner already wrote the clean answer in the same call as their reasoning, so there is no semantic divergence between what voters read and what gets published.
+- Simpler implementation (one parser + one write path) vs. two new debate stages, two new prompts, and a validator-honesty problem.
+
+**Risk acknowledged:** the council's "instruction overflow" critique partially applies — the R2 prompt becomes more demanding. Mitigation: (a) JSON is more enforceable than free-text markers across vendors, (b) fail-closed → raw R2 means worst case is exactly today's behavior, (c) we measure parse success rates after rollout and pivot to B + validation if compliance is unreliable.
+
+## Context (from discovery)
+
+- **Issue:** [#16](https://github.com/fitz123/council/issues/16) — full design discussion + council recommendation.
+- **Council session:** `.council/sessions/2026-04-27T21-24-13Z-pleasantly-above-maggot/` — 2-1 verdict for B + validation, with structured-extraction promoted by 2/3 R2 responses as the stronger third option.
+- **Files involved:**
+  - `defaults/prompts/peer-aware.md` — append JSON-tail requirement (current rules at lines 34–36 instruct "no meta-commentary"; that line stays, JSON requirement is additive).
+  - `pkg/debate/vote.go` — `SelectOutput` (lines 348–) currently writes winner's R2 verbatim; this is where extraction wires in.
+  - `pkg/debate/` — new file `extract.go` for the JSON parser + extraction logic.
+  - `pkg/session/verdict.go` — add extraction outcome to verdict.json.
+  - `cmd/council/reporter.go` — verbose stream gets a one-line extraction event.
+  - `pkg/debate/reporter.go` — stage event for extraction (stream emit).
+- **Patterns to follow:**
+  - Profile schema additions in `pkg/config/config.go` lines 16–25 if new prompt fields are needed (none for this plan — peer-aware.md already covers it).
+  - `.done` markers on per-stage idempotency — extraction is part of `SelectOutput`, which is already idempotent on `output.md` existence; no new marker needed.
+  - Table-driven Go tests with subtests (existing pattern in `vote_test.go`, `rounds_test.go`).
+  - Verdict.json schema is documented in `pkg/session/verdict.go`; new field documented there.
+- **Out of scope explicitly:**
+  - Not changing what voters see (ballot prompt continues to receive full R2 — verbosity-bias question is unresolved in literature; do not change on speculation).
+  - Not bumping `verdict.json.version` (additive metadata field; existing consumers ignore unknown fields).
+  - Not adding a feature flag (per repo convention: single-user, no backward-compat shims, just describe new behavior).
+
+## Development Approach
+
+- **Testing approach:** Regular (write tests alongside code, table-driven — existing project pattern).
+- Complete each task fully before moving to the next.
+- Make small, focused changes.
+- **CRITICAL: every task MUST include new/updated tests** for code changes in that task.
+  - Write unit tests for the extractor's success cases.
+  - Write unit tests for every fail-closed path (no JSON block, malformed JSON, missing `answer` key, empty `answer` string, JSON without code fence, multiple JSON blocks — extract last).
+  - Update `vote_test.go` for the SelectOutput integration.
+- **CRITICAL: all tests must pass before starting next task.**
+- **CRITICAL: update this plan file when scope changes during implementation.**
+- Run `go test ./...` after each change.
+
+## Testing Strategy
+
+- **Unit tests:** extractor parser (table-driven), SelectOutput integration (success + each fallback path), verdict-shape assertions.
+- **No e2e:** project does not have UI e2e infrastructure.
+- **Manual smoke:** run `council` against a known question after implementation; eyeball that `output.md` is clean and that `rounds/r2/<winner>.txt` still has the full debate text.
+
+## Progress Tracking
+
+- Mark completed items with `[x]` immediately when done.
+- Add newly discovered tasks with ➕ prefix.
+- Document issues/blockers with ⚠️ prefix.
+- Update plan if implementation deviates from original scope.
+
+## What Goes Where
+
+- **Implementation Steps** (`[ ]` checkboxes): code, tests, docs achievable in this repo.
+- **Post-Completion** (no checkboxes): manual smoke, parse-rate observation across real sessions, deciding whether to pivot to B + validation.
+
+## Implementation Steps
+
+### Task 1: Update peer-aware.md prompt to require trailing JSON block
+
+- [ ] read `defaults/prompts/peer-aware.md` and identify the format-rules section (currently lines 34–36).
+- [ ] append a new section instructing the expert to end the response with a fenced JSON code block: `{"answer": "<3–8 sentence clean standalone answer; no peer references; preserve URL citations inline>", "citations": ["<url>", ...]}`. Keep the existing "no meta-commentary" line — they reinforce each other.
+- [ ] explicitly state that the JSON block must be the LAST content in the response, separated from the prose by a blank line, and that prose with peer references is allowed before the JSON block (the prose feeds voters; the JSON feeds the published output).
+- [ ] write a unit test that loads the prompt file and asserts both (a) the no-meta-commentary line still exists, (b) a fenced JSON example with `"answer"` key is present, (c) the prompt mentions the LAST-content requirement.
+- [ ] run `go test ./pkg/config/...` — must pass before task 2.
+
+### Task 2: Implement JSON extractor in pkg/debate/extract.go
+
+- [ ] create new file `pkg/debate/extract.go` with `ExtractAnswer(raw string) (answer string, status ExtractStatus)`.
+- [ ] define `ExtractStatus` enum: `ExtractOK`, `ExtractNoJSONBlock`, `ExtractInvalidJSON`, `ExtractMissingAnswer`, `ExtractEmptyAnswer`.
+- [ ] parse strategy: scan for the LAST fenced code block (` ```json ... ``` ` or generic ` ``` ... ``` ` whose content begins with `{`); decode with `encoding/json`; require `answer` to be a non-empty string after trimming whitespace.
+- [ ] do NOT validate the `citations` field — defensive parsing only on `answer`. Citations are operator-level metadata; ignore.
+- [ ] when status is anything other than `ExtractOK`, the returned `answer` is the empty string.
+- [ ] no logging, no errors — pure function returning (string, status).
+- [ ] write `pkg/debate/extract_test.go` with table-driven cases:
+  - happy path: simple JSON block with `answer` → returns text + OK.
+  - happy path: JSON block with `answer` and `citations[]` → ignores citations, returns answer + OK.
+  - JSON block with leading/trailing whitespace in `answer` → trims, returns OK.
+  - prose with multiple JSON blocks → extracts the LAST one.
+  - JSON block without code fence (raw `{...}` at end of text) → must NOT extract; return `ExtractNoJSONBlock` (require fences for unambiguity).
+  - empty input → `ExtractNoJSONBlock`.
+  - malformed JSON inside fences → `ExtractInvalidJSON`.
+  - JSON missing `answer` key → `ExtractMissingAnswer`.
+  - JSON with `answer: ""` (empty after trim) → `ExtractEmptyAnswer`.
+  - JSON with `answer: null` → `ExtractMissingAnswer` (null treated as missing).
+  - JSON with `answer` as a number/array/object → `ExtractMissingAnswer` (require string type).
+  - prose containing the literal text "```json" inside a quoted block but no real fence → `ExtractNoJSONBlock`.
+- [ ] run `go test ./pkg/debate/ -run TestExtract` — must pass before task 3.
+
+### Task 3: Wire extractor into SelectOutput
+
+- [ ] in `pkg/debate/vote.go`, locate the winner-write branch in `SelectOutput` (lines 381–388).
+- [ ] before writing `output.md`, call `ExtractAnswer(r.Body)`. If status is `ExtractOK`, write the extracted answer string (with a single trailing newline) to `output.md`. Otherwise, fall back to writing `r.Body` unchanged.
+- [ ] do NOT touch the tied-candidates branch — ties already surface multiple files; extraction in that branch is out of scope and can be added later if needed.
+- [ ] return the extraction status from `SelectOutput` so the caller can record it in verdict.json (or accept a callback / extend the result struct — pick whichever fits the existing signature with the smallest delta).
+- [ ] update `pkg/debate/vote_test.go` to assert: when winner R2 contains a valid JSON tail, `output.md` contains only the extracted answer (not the raw R2). When winner R2 has no JSON tail, `output.md` contains the raw R2 (existing behavior preserved).
+- [ ] add a regression test: winner R2 contains malformed JSON → `output.md` is the raw R2, no panic, status reflects the fallback reason.
+- [ ] run `go test ./pkg/debate/...` — must pass before task 4.
+
+### Task 4: Record extraction outcome in verdict.json
+
+- [ ] in `pkg/session/verdict.go`, add a top-level field `AnswerExtraction` (struct) to the verdict shape: `{ "status": "ok" | "fallback_no_json" | "fallback_invalid_json" | "fallback_missing_answer" | "fallback_empty_answer", "winner_label": "B" }`. Use `omitempty` on the struct so resumed sessions that predate this field still serialize cleanly.
+- [ ] update `pkg/session/verdict_test.go` canonical fixture (`testdata/verdict_canonical.json`) to include the new field on a happy-path verdict.
+- [ ] update the verdict-write call sites (orchestrator main path) to populate the field from `SelectOutput`'s returned status.
+- [ ] document the field in the verdict.json schema comment block at the top of `pkg/session/verdict.go`.
+- [ ] write tests: verdict.json contains `answer_extraction.status: "ok"` on extraction success; contains `"fallback_*"` matching the reason on each fallback path.
+- [ ] run `go test ./pkg/session/...` and `go test ./pkg/debate/...` — must pass before task 5.
+
+### Task 5: Verbose-stream event for extraction outcome
+
+- [ ] in `pkg/debate/reporter.go` (or wherever stage events are defined), add an extraction event type carrying the winner label and the extraction status.
+- [ ] in `cmd/council/reporter.go`, add a renderer for the new event:
+  - On `ExtractOK`: `[hh:mm:ss] extracted clean answer from winner B (claude_expert): N chars`
+  - On any fallback: `[hh:mm:ss] extraction fell back to raw R2 from winner B (claude_expert): <reason>`
+- [ ] emit the event from `SelectOutput` (or its caller) after the write completes.
+- [ ] write tests for `reporter_test.go` covering both lines.
+- [ ] run `go test ./...` — must pass before task 6.
+
+### Task 6: Verify acceptance criteria
+
+- [ ] verify all requirements from Overview are implemented:
+  - Winner's clean answer becomes `verdict.answer` and `output.md` when JSON extraction succeeds.
+  - Raw R2 fallback writes the same content as today on every failure path.
+  - `rounds/r2/<label>.txt` is unchanged for every expert (always full body).
+  - `verdict.json.answer_extraction` records the outcome.
+- [ ] verify edge cases are handled (each `ExtractStatus` value has at least one test).
+- [ ] run full test suite: `go test ./...` — all green.
+- [ ] run linter: `go vet ./...` and any project-specific linter — fix any issues.
+- [ ] verify test coverage of `pkg/debate/extract.go` is >= 90% (measure with `go test -cover ./pkg/debate/`).
+- [ ] manual smoke: run `council` against a real question and confirm `output.md` no longer contains "Эксперт A/B/C" references on success path.
+
+### Task 7: Update documentation
+
+- [ ] update `README.md`: under "What's new in v2" (or wherever post-v2 changes are listed), add a one-paragraph note that the published answer is now a clean extraction from the winner's R2 JSON tail, with raw R2 preserved in `rounds/r2/`.
+- [ ] add ADR `docs/adr/0014-json-extraction-published-answer.md` following the existing ADR template (Status, Context, Alternatives, Decision, Consequences, Compliance, Research, Supersedes/Extends).
+  - Status: Accepted (cite session 2026-04-27T21-24-13Z-pleasantly-above-maggot + issue #16).
+  - Decision: JSON-tail extraction with fail-closed → raw R2 fallback.
+  - Alternatives evaluated: B + validation pass (council's headline), text-marker section format, mechanical regex strip.
+  - Compliance fitness function: `jq -e '.answer_extraction.status == "ok" or (.answer_extraction.status | startswith("fallback_"))' verdict.json` returns true on every session.
+- [ ] reference issue #16 and the council session in the ADR's "Research" section.
+- [ ] no `verdict.json.version` bump (additive change; consumers ignore unknown fields).
+
+*Note: ralphex automatically moves completed plans to `docs/plans/completed/`.*
+
+## Technical Details
+
+### Parser contract
+
+```go
+type ExtractStatus int
+
+const (
+    ExtractOK ExtractStatus = iota
+    ExtractNoJSONBlock
+    ExtractInvalidJSON
+    ExtractMissingAnswer  // null, missing, wrong type
+    ExtractEmptyAnswer    // empty string after trim
+)
+
+func ExtractAnswer(raw string) (answer string, status ExtractStatus)
+```
+
+### Parse algorithm
+
+1. Find all fenced code blocks in `raw` matching ```` ```(json)?\n([\s\S]*?)\n``` ````.
+2. If zero matches → `ExtractNoJSONBlock`.
+3. Take the LAST match's content. Trim leading/trailing whitespace.
+4. `json.Unmarshal` into `map[string]any`. On error → `ExtractInvalidJSON`.
+5. Look up key `answer`. If absent, null, or non-string → `ExtractMissingAnswer`.
+6. Trim whitespace from the answer string. If empty → `ExtractEmptyAnswer`.
+7. Return (answer, `ExtractOK`).
+
+### Verdict.json shape addition
+
+```json
+{
+  "version": 2,
+  "...": "existing fields unchanged",
+  "answer_extraction": {
+    "status": "ok",
+    "winner_label": "B"
+  }
+}
+```
+
+Status values: `ok | fallback_no_json | fallback_invalid_json | fallback_missing_answer | fallback_empty_answer`. Field is omitted on ties (no winner) and on sessions where `SelectOutput` did not run.
+
+### peer-aware.md changes
+
+Append (do not replace) a section roughly:
+
+```
+Output discipline:
+- Your response is in two halves separated by a blank line.
+- First half: your peer-engaged refinement, citing peers and URLs.
+- Second half (LAST in the response, after a blank line): a fenced JSON
+  code block with this exact shape:
+
+  ```json
+  {
+    "answer": "<3-8 sentence clean standalone answer to the original question; no references to peers; preserve URL citations inline>",
+    "citations": ["<url>", "<url>"]
+  }
+  ```
+
+The JSON block is what gets published as the final answer. The prose
+above it is what voters use to evaluate engagement and verification.
+```
+
+The "No meta-commentary about the debate process itself" line stays — it now applies specifically to the JSON `answer` field.
+
+## Post-Completion
+
+*Items requiring manual intervention or external systems — no checkboxes, informational only.*
+
+**Empirical observation period:**
+- Run 5–10 real council sessions across mixed question types after merge.
+- Inspect each `verdict.json.answer_extraction.status`: count `ok` vs `fallback_*`.
+- If parse success rate is ≥ 90% across all three vendors → ship as-is.
+- If parse success rate is < 90% on any single vendor (Claude / Codex / Gemini) → open a follow-up issue to (a) tune the prompt for that vendor or (b) implement B + validation as the salvage path.
+
+**Manual verification:**
+- Eyeball `output.md` of 3–5 sessions to confirm it reads as a clean answer to the original question with no "Expert A/B/C" references.
+- Compare `output.md` vs. `rounds/r2/<winner>.txt` on a few sessions to confirm no information loss in the answer field.
+
+**Follow-up work (potential, not in this plan):**
+- Apply the same extraction in the tied-candidates path (multi-winner ties) — out of scope here, separate issue.
+- Decide whether voters should see the JSON block stripped from candidate text — current behavior keeps it visible; revisit only if vote quality regressions are observed.

--- a/docs/plans/2026-04-28-clean-published-answer-json-extraction.md
+++ b/docs/plans/2026-04-28-clean-published-answer-json-extraction.md
@@ -82,13 +82,13 @@ This is "Option A done right" (per the council session 2026-04-27T21-24-13Z-plea
 
 ### Task 2: Implement JSON extractor in pkg/debate/extract.go
 
-- [ ] create new file `pkg/debate/extract.go` with `ExtractAnswer(raw string) (answer string, status ExtractStatus)`.
-- [ ] define `ExtractStatus` enum: `ExtractOK`, `ExtractNoJSONBlock`, `ExtractInvalidJSON`, `ExtractMissingAnswer`, `ExtractEmptyAnswer`.
-- [ ] parse strategy: scan for the LAST fenced code block (` ```json ... ``` ` or generic ` ``` ... ``` ` whose content begins with `{`); decode with `encoding/json`; require `answer` to be a non-empty string after trimming whitespace.
-- [ ] do NOT validate the `citations` field — defensive parsing only on `answer`. Citations are operator-level metadata; ignore.
-- [ ] when status is anything other than `ExtractOK`, the returned `answer` is the empty string.
-- [ ] no logging, no errors — pure function returning (string, status).
-- [ ] write `pkg/debate/extract_test.go` with table-driven cases:
+- [x] create new file `pkg/debate/extract.go` with `ExtractAnswer(raw string) (answer string, status ExtractStatus)`.
+- [x] define `ExtractStatus` enum: `ExtractOK`, `ExtractNoJSONBlock`, `ExtractInvalidJSON`, `ExtractMissingAnswer`, `ExtractEmptyAnswer`.
+- [x] parse strategy: scan for the LAST fenced code block (` ```json ... ``` ` or generic ` ``` ... ``` ` whose content begins with `{`); decode with `encoding/json`; require `answer` to be a non-empty string after trimming whitespace.
+- [x] do NOT validate the `citations` field — defensive parsing only on `answer`. Citations are operator-level metadata; ignore.
+- [x] when status is anything other than `ExtractOK`, the returned `answer` is the empty string.
+- [x] no logging, no errors — pure function returning (string, status).
+- [x] write `pkg/debate/extract_test.go` with table-driven cases:
   - happy path: simple JSON block with `answer` → returns text + OK.
   - happy path: JSON block with `answer` and `citations[]` → ignores citations, returns answer + OK.
   - JSON block with leading/trailing whitespace in `answer` → trims, returns OK.
@@ -101,7 +101,7 @@ This is "Option A done right" (per the council session 2026-04-27T21-24-13Z-plea
   - JSON with `answer: null` → `ExtractMissingAnswer` (null treated as missing).
   - JSON with `answer` as a number/array/object → `ExtractMissingAnswer` (require string type).
   - prose containing the literal text "```json" inside a quoted block but no real fence → `ExtractNoJSONBlock`.
-- [ ] run `go test ./pkg/debate/ -run TestExtract` — must pass before task 3.
+- [x] run `go test ./pkg/debate/ -run TestExtract` — must pass before task 3.
 
 ### Task 3: Wire extractor into SelectOutput
 

--- a/docs/plans/2026-04-28-clean-published-answer-json-extraction.md
+++ b/docs/plans/2026-04-28-clean-published-answer-json-extraction.md
@@ -134,16 +134,16 @@ This is "Option A done right" (per the council session 2026-04-27T21-24-13Z-plea
 
 ### Task 6: Verify acceptance criteria
 
-- [ ] verify all requirements from Overview are implemented:
+- [x] verify all requirements from Overview are implemented:
   - Winner's clean answer becomes `verdict.answer` and `output.md` when JSON extraction succeeds.
   - Raw R2 fallback writes the same content as today on every failure path.
   - `rounds/r2/<label>.txt` is unchanged for every expert (always full body).
   - `verdict.json.answer_extraction` records the outcome.
-- [ ] verify edge cases are handled (each `ExtractStatus` value has at least one test).
-- [ ] run full test suite: `go test ./...` — all green.
-- [ ] run linter: `go vet ./...` and any project-specific linter — fix any issues.
-- [ ] verify test coverage of `pkg/debate/extract.go` is >= 90% (measure with `go test -cover ./pkg/debate/`).
-- [ ] manual smoke: run `council` against a real question and confirm `output.md` no longer contains "Эксперт A/B/C" references on success path.
+- [x] verify edge cases are handled (each `ExtractStatus` value has at least one test).
+- [x] run full test suite: `go test ./...` — all green.
+- [x] run linter: `go vet ./...` and any project-specific linter — fix any issues.
+- [x] verify test coverage of `pkg/debate/extract.go` is >= 90% (measure with `go test -cover ./pkg/debate/`). Per-function coverage 100%; package overall 92.7%.
+- [x] manual smoke (skipped - not automatable): requires real council run against a live question; verified by post-completion observation period.
 
 ### Task 7: Update documentation
 

--- a/docs/plans/2026-04-28-clean-published-answer-json-extraction.md
+++ b/docs/plans/2026-04-28-clean-published-answer-json-extraction.md
@@ -74,11 +74,11 @@ This is "Option A done right" (per the council session 2026-04-27T21-24-13Z-plea
 
 ### Task 1: Update peer-aware.md prompt to require trailing JSON block
 
-- [ ] read `defaults/prompts/peer-aware.md` and identify the format-rules section (currently lines 34–36).
-- [ ] append a new section instructing the expert to end the response with a fenced JSON code block: `{"answer": "<3–8 sentence clean standalone answer; no peer references; preserve URL citations inline>", "citations": ["<url>", ...]}`. Keep the existing "no meta-commentary" line — they reinforce each other.
-- [ ] explicitly state that the JSON block must be the LAST content in the response, separated from the prose by a blank line, and that prose with peer references is allowed before the JSON block (the prose feeds voters; the JSON feeds the published output).
-- [ ] write a unit test that loads the prompt file and asserts both (a) the no-meta-commentary line still exists, (b) a fenced JSON example with `"answer"` key is present, (c) the prompt mentions the LAST-content requirement.
-- [ ] run `go test ./pkg/config/...` — must pass before task 2.
+- [x] read `defaults/prompts/peer-aware.md` and identify the format-rules section (currently lines 34–36).
+- [x] append a new section instructing the expert to end the response with a fenced JSON code block: `{"answer": "<3–8 sentence clean standalone answer; no peer references; preserve URL citations inline>", "citations": ["<url>", ...]}`. Keep the existing "no meta-commentary" line — they reinforce each other.
+- [x] explicitly state that the JSON block must be the LAST content in the response, separated from the prose by a blank line, and that prose with peer references is allowed before the JSON block (the prose feeds voters; the JSON feeds the published output).
+- [x] write a unit test that loads the prompt file and asserts both (a) the no-meta-commentary line still exists, (b) a fenced JSON example with `"answer"` key is present, (c) the prompt mentions the LAST-content requirement.
+- [x] run `go test ./pkg/config/...` — must pass before task 2.
 
 ### Task 2: Implement JSON extractor in pkg/debate/extract.go
 

--- a/docs/plans/2026-04-28-clean-published-answer-json-extraction.md
+++ b/docs/plans/2026-04-28-clean-published-answer-json-extraction.md
@@ -115,12 +115,12 @@ This is "Option A done right" (per the council session 2026-04-27T21-24-13Z-plea
 
 ### Task 4: Record extraction outcome in verdict.json
 
-- [ ] in `pkg/session/verdict.go`, add a top-level field `AnswerExtraction` (struct) to the verdict shape: `{ "status": "ok" | "fallback_no_json" | "fallback_invalid_json" | "fallback_missing_answer" | "fallback_empty_answer", "winner_label": "B" }`. Use `omitempty` on the struct so resumed sessions that predate this field still serialize cleanly.
-- [ ] update `pkg/session/verdict_test.go` canonical fixture (`testdata/verdict_canonical.json`) to include the new field on a happy-path verdict.
-- [ ] update the verdict-write call sites (orchestrator main path) to populate the field from `SelectOutput`'s returned status.
-- [ ] document the field in the verdict.json schema comment block at the top of `pkg/session/verdict.go`.
-- [ ] write tests: verdict.json contains `answer_extraction.status: "ok"` on extraction success; contains `"fallback_*"` matching the reason on each fallback path.
-- [ ] run `go test ./pkg/session/...` and `go test ./pkg/debate/...` — must pass before task 5.
+- [x] in `pkg/session/verdict.go`, add a top-level field `AnswerExtraction` (struct) to the verdict shape: `{ "status": "ok" | "fallback_no_json" | "fallback_invalid_json" | "fallback_missing_answer" | "fallback_empty_answer", "winner_label": "B" }`. Use `omitempty` on the struct so resumed sessions that predate this field still serialize cleanly.
+- [x] update `pkg/session/verdict_test.go` canonical fixture (`testdata/verdict_canonical.json`) to include the new field on a happy-path verdict.
+- [x] update the verdict-write call sites (orchestrator main path) to populate the field from `SelectOutput`'s returned status.
+- [x] document the field in the verdict.json schema comment block at the top of `pkg/session/verdict.go`.
+- [x] write tests: verdict.json contains `answer_extraction.status: "ok"` on extraction success; contains `"fallback_*"` matching the reason on each fallback path.
+- [x] run `go test ./pkg/session/...` and `go test ./pkg/debate/...` — must pass before task 5.
 
 ### Task 5: Verbose-stream event for extraction outcome
 

--- a/docs/plans/2026-04-28-clean-published-answer-json-extraction.md
+++ b/docs/plans/2026-04-28-clean-published-answer-json-extraction.md
@@ -124,13 +124,13 @@ This is "Option A done right" (per the council session 2026-04-27T21-24-13Z-plea
 
 ### Task 5: Verbose-stream event for extraction outcome
 
-- [ ] in `pkg/debate/reporter.go` (or wherever stage events are defined), add an extraction event type carrying the winner label and the extraction status.
-- [ ] in `cmd/council/reporter.go`, add a renderer for the new event:
+- [x] in `pkg/debate/reporter.go` (or wherever stage events are defined), add an extraction event type carrying the winner label and the extraction status.
+- [x] in `cmd/council/reporter.go`, add a renderer for the new event:
   - On `ExtractOK`: `[hh:mm:ss] extracted clean answer from winner B (claude_expert): N chars`
   - On any fallback: `[hh:mm:ss] extraction fell back to raw R2 from winner B (claude_expert): <reason>`
-- [ ] emit the event from `SelectOutput` (or its caller) after the write completes.
-- [ ] write tests for `reporter_test.go` covering both lines.
-- [ ] run `go test ./...` — must pass before task 6.
+- [x] emit the event from `SelectOutput` (or its caller) after the write completes.
+- [x] write tests for `reporter_test.go` covering both lines.
+- [x] run `go test ./...` — must pass before task 6.
 
 ### Task 6: Verify acceptance criteria
 

--- a/docs/plans/2026-04-28-clean-published-answer-json-extraction.md
+++ b/docs/plans/2026-04-28-clean-published-answer-json-extraction.md
@@ -105,13 +105,13 @@ This is "Option A done right" (per the council session 2026-04-27T21-24-13Z-plea
 
 ### Task 3: Wire extractor into SelectOutput
 
-- [ ] in `pkg/debate/vote.go`, locate the winner-write branch in `SelectOutput` (lines 381–388).
-- [ ] before writing `output.md`, call `ExtractAnswer(r.Body)`. If status is `ExtractOK`, write the extracted answer string (with a single trailing newline) to `output.md`. Otherwise, fall back to writing `r.Body` unchanged.
-- [ ] do NOT touch the tied-candidates branch — ties already surface multiple files; extraction in that branch is out of scope and can be added later if needed.
-- [ ] return the extraction status from `SelectOutput` so the caller can record it in verdict.json (or accept a callback / extend the result struct — pick whichever fits the existing signature with the smallest delta).
-- [ ] update `pkg/debate/vote_test.go` to assert: when winner R2 contains a valid JSON tail, `output.md` contains only the extracted answer (not the raw R2). When winner R2 has no JSON tail, `output.md` contains the raw R2 (existing behavior preserved).
-- [ ] add a regression test: winner R2 contains malformed JSON → `output.md` is the raw R2, no panic, status reflects the fallback reason.
-- [ ] run `go test ./pkg/debate/...` — must pass before task 4.
+- [x] in `pkg/debate/vote.go`, locate the winner-write branch in `SelectOutput` (lines 381–388).
+- [x] before writing `output.md`, call `ExtractAnswer(r.Body)`. If status is `ExtractOK`, write the extracted answer string (with a single trailing newline) to `output.md`. Otherwise, fall back to writing `r.Body` unchanged.
+- [x] do NOT touch the tied-candidates branch — ties already surface multiple files; extraction in that branch is out of scope and can be added later if needed.
+- [x] return the extraction status from `SelectOutput` so the caller can record it in verdict.json (or accept a callback / extend the result struct — pick whichever fits the existing signature with the smallest delta).
+- [x] update `pkg/debate/vote_test.go` to assert: when winner R2 contains a valid JSON tail, `output.md` contains only the extracted answer (not the raw R2). When winner R2 has no JSON tail, `output.md` contains the raw R2 (existing behavior preserved).
+- [x] add a regression test: winner R2 contains malformed JSON → `output.md` is the raw R2, no panic, status reflects the fallback reason.
+- [x] run `go test ./pkg/debate/...` — must pass before task 4.
 
 ### Task 4: Record extraction outcome in verdict.json
 

--- a/pkg/config/embed_test.go
+++ b/pkg/config/embed_test.go
@@ -71,6 +71,36 @@ func TestLoadFromEmbedded_ProfileShape(t *testing.T) {
 	}
 }
 
+// TestLoadFromEmbedded_PeerAwareJSONTail locks in the contract that the
+// peer-aware (R2) prompt instructs experts to (a) avoid meta-commentary in
+// the published answer, (b) end the response with a fenced JSON block
+// containing an "answer" field, and (c) make that JSON block the LAST
+// content in the response. Drift here breaks the JSON-extraction pipeline
+// in pkg/debate/extract.go.
+func TestLoadFromEmbedded_PeerAwareJSONTail(t *testing.T) {
+	p, err := loadFromEmbedded()
+	if err != nil {
+		t.Fatalf("loadFromEmbedded: %v", err)
+	}
+	body := p.Round2Prompt.Body
+
+	if !strings.Contains(body, "No meta-commentary about the\ndebate process itself.") &&
+		!strings.Contains(body, "No meta-commentary about the debate process itself.") {
+		t.Errorf("peer-aware.md missing the no-meta-commentary directive; body:\n%s", body)
+	}
+
+	if !strings.Contains(body, "```json") {
+		t.Errorf("peer-aware.md missing a fenced ```json example; body:\n%s", body)
+	}
+	if !strings.Contains(body, `"answer"`) {
+		t.Errorf("peer-aware.md missing the \"answer\" JSON key; body:\n%s", body)
+	}
+
+	if !strings.Contains(body, "LAST") {
+		t.Errorf("peer-aware.md missing the LAST-content requirement for the JSON block; body:\n%s", body)
+	}
+}
+
 // TestLoadFromEmbedded_F7EarlyUnknownField is the F7 early gate: a local
 // config with an unknown top-level field (e.g. `effort: bogus`) must be
 // rejected by Load before the orchestrator ever spawns. cmd/council maps

--- a/pkg/debate/extract.go
+++ b/pkg/debate/extract.go
@@ -1,0 +1,133 @@
+// This file implements the JSON-tail extractor for published answers.
+// Per ADR-0014 (json-extraction-published-answer), every R2 response must
+// end with a fenced JSON code block carrying a clean `answer` field. The
+// orchestrator extracts that field and writes it to output.md instead of
+// the raw R2 body, which contains debate meta-commentary referring to
+// other experts. When extraction fails, the caller falls back to writing
+// the raw R2 unchanged — strictly today's behavior, no regression.
+//
+// ExtractAnswer is intentionally a pure function: no logging, no errors,
+// no I/O. The caller decides what to do with each fail-closed status.
+
+package debate
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// ExtractStatus reports the outcome of ExtractAnswer. Every value other
+// than ExtractOK means the caller should fall back to writing the raw R2
+// body so that no answer is ever lost to a parser bug.
+type ExtractStatus int
+
+const (
+	// ExtractOK indicates a clean, non-empty answer string was found.
+	ExtractOK ExtractStatus = iota
+	// ExtractNoJSONBlock indicates no fenced ```...``` block was found.
+	ExtractNoJSONBlock
+	// ExtractInvalidJSON indicates the fenced block did not parse as JSON.
+	ExtractInvalidJSON
+	// ExtractMissingAnswer indicates the JSON parsed but `answer` is
+	// absent, null, or not a string.
+	ExtractMissingAnswer
+	// ExtractEmptyAnswer indicates `answer` is a string but empty after
+	// trimming surrounding whitespace.
+	ExtractEmptyAnswer
+)
+
+// ExtractAnswer scans raw for the LAST fenced code block and returns the
+// value of its top-level `answer` field. Pure function: no logging, no
+// errors. Callers inspect the returned status and fall back to writing
+// the raw R2 body whenever status != ExtractOK.
+//
+// The scan requires explicit code fences. Bare `{...}` at the end of
+// prose is rejected (ExtractNoJSONBlock) so unstructured trailing JSON
+// in a peer's argument cannot be mistaken for the published answer.
+func ExtractAnswer(raw string) (answer string, status ExtractStatus) {
+	blocks := findFencedBlocks(raw)
+	if len(blocks) == 0 {
+		return "", ExtractNoJSONBlock
+	}
+	body := strings.TrimSpace(blocks[len(blocks)-1])
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		return "", ExtractInvalidJSON
+	}
+	v, ok := parsed["answer"]
+	if !ok || v == nil {
+		return "", ExtractMissingAnswer
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", ExtractMissingAnswer
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", ExtractEmptyAnswer
+	}
+	return s, ExtractOK
+}
+
+// findFencedBlocks returns the bodies of all fenced code blocks in raw,
+// in document order. A fence is three backticks at the start of a line
+// (optionally with an info-string like `json`), and the closing fence is
+// three backticks at the start of a line. The fence-open line and the
+// fence-close line are excluded from the body.
+//
+// Implemented by hand instead of regexp so the line-anchoring is precise
+// across CRLF and trailing-whitespace edge cases. Backticks appearing
+// mid-line (e.g. inside a quoted string) are correctly ignored — they
+// never start with column 0 of a line, so they cannot match a fence.
+func findFencedBlocks(raw string) []string {
+	var blocks []string
+	lines := strings.Split(raw, "\n")
+	i := 0
+	for i < len(lines) {
+		line := strings.TrimRight(lines[i], "\r")
+		if !isFenceOpen(line) {
+			i++
+			continue
+		}
+		start := i + 1
+		j := start
+		for j < len(lines) {
+			inner := strings.TrimRight(lines[j], "\r")
+			if inner == "```" {
+				blocks = append(blocks, strings.Join(lines[start:j], "\n"))
+				i = j + 1
+				break
+			}
+			j++
+		}
+		if j >= len(lines) {
+			// unterminated fence — ignore; caller falls back to raw R2
+			return blocks
+		}
+	}
+	return blocks
+}
+
+// isFenceOpen reports whether line is an opening fence: exactly three
+// backticks optionally followed by an info-string of [a-zA-Z0-9_-]
+// characters and nothing else. The strict info-string charset rejects
+// unusual variants ("``` json", trailing spaces) so the parser's notion
+// of a fence matches what conventional markdown renderers consider one.
+func isFenceOpen(line string) bool {
+	if !strings.HasPrefix(line, "```") {
+		return false
+	}
+	rest := line[3:]
+	for _, r := range rest {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '_' || r == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/debate/extract.go
+++ b/pkg/debate/extract.go
@@ -36,6 +36,33 @@ const (
 	ExtractEmptyAnswer
 )
 
+// VerdictStatus returns the wire-format string for verdict.json's
+// answer_extraction.status field (ADR-0014). ExtractOK maps to "ok"; every
+// fail-closed value maps to "fallback_<reason>" so a single jq probe
+// (`.answer_extraction.status == "ok" or
+// (.answer_extraction.status | startswith("fallback_"))`) can verify the
+// invariant across every session.
+//
+// An unknown ExtractStatus (defensive — should never occur) maps to
+// "fallback_unknown" so the field is always serializable rather than
+// panicking on a future enum extension that forgot to update this map.
+func (s ExtractStatus) VerdictStatus() string {
+	switch s {
+	case ExtractOK:
+		return "ok"
+	case ExtractNoJSONBlock:
+		return "fallback_no_json"
+	case ExtractInvalidJSON:
+		return "fallback_invalid_json"
+	case ExtractMissingAnswer:
+		return "fallback_missing_answer"
+	case ExtractEmptyAnswer:
+		return "fallback_empty_answer"
+	default:
+		return "fallback_unknown"
+	}
+}
+
 // ExtractAnswer scans raw for the LAST fenced code block and returns the
 // value of its top-level `answer` field. Pure function: no logging, no
 // errors. Callers inspect the returned status and fall back to writing

--- a/pkg/debate/extract.go
+++ b/pkg/debate/extract.go
@@ -63,20 +63,52 @@ func (s ExtractStatus) VerdictStatus() string {
 	}
 }
 
-// ExtractAnswer scans raw for the LAST fenced code block and returns the
-// value of its top-level `answer` field. Pure function: no logging, no
-// errors. Callers inspect the returned status and fall back to writing
-// the raw R2 body whenever status != ExtractOK.
+// ExtractAnswer scans raw for a fenced JSON-candidate block at the very
+// tail of the response and returns the value of its top-level `answer`
+// field. Pure function: no logging, no errors. Callers inspect the
+// returned status and fall back to writing the raw R2 body whenever
+// status != ExtractOK.
+//
+// A JSON-candidate block is either an explicitly tagged ```json fence,
+// or an untagged ``` fence whose trimmed body begins with `{`. Earlier
+// JSON blocks in the response are NOT considered: peer-aware.md
+// requires the JSON block to be the last content (nothing after the
+// closing fence). If the LAST fenced block is a non-JSON language
+// (```bash, ```python, ...), or if any non-whitespace content follows
+// the closing fence, the result is ExtractNoJSONBlock — accurately
+// attributing the absence of a JSON tail rather than silently
+// publishing a stale draft from earlier in the body.
 //
 // The scan requires explicit code fences. Bare `{...}` at the end of
 // prose is rejected (ExtractNoJSONBlock) so unstructured trailing JSON
 // in a peer's argument cannot be mistaken for the published answer.
 func ExtractAnswer(raw string) (answer string, status ExtractStatus) {
-	blocks := findFencedBlocks(raw)
+	lines := splitLines(raw)
+	blocks := findFencedBlocks(lines)
 	if len(blocks) == 0 {
 		return "", ExtractNoJSONBlock
 	}
-	body := strings.TrimSpace(blocks[len(blocks)-1])
+	last := blocks[len(blocks)-1]
+	// Tail enforcement: the JSON block must be the LAST content. Any
+	// non-whitespace line after the closing fence disqualifies the
+	// block — we won't extract a stale draft followed by prose or by
+	// another (non-JSON) code fence.
+	for _, line := range lines[last.closeIdx+1:] {
+		if strings.TrimSpace(line) != "" {
+			return "", ExtractNoJSONBlock
+		}
+	}
+	body := strings.TrimSpace(last.body)
+	switch last.lang {
+	case "json":
+		// candidate
+	case "":
+		if !strings.HasPrefix(body, "{") {
+			return "", ExtractNoJSONBlock
+		}
+	default:
+		return "", ExtractNoJSONBlock
+	}
 
 	var parsed map[string]any
 	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
@@ -97,32 +129,56 @@ func ExtractAnswer(raw string) (answer string, status ExtractStatus) {
 	return s, ExtractOK
 }
 
-// findFencedBlocks returns the bodies of all fenced code blocks in raw,
-// in document order. A fence is three backticks at the start of a line
-// (optionally with an info-string like `json`), and the closing fence is
-// three backticks at the start of a line. The fence-open line and the
-// fence-close line are excluded from the body.
+// fencedBlock holds one fenced code block: its info-string (language
+// tag, e.g. "json", "bash", or "" for an untagged fence), the raw body
+// between the open and close fences, and the index of the closing
+// fence line in the source `lines` slice (used by the tail-enforcement
+// check above).
+type fencedBlock struct {
+	lang     string
+	body     string
+	closeIdx int
+}
+
+// splitLines splits raw on "\n" and trims trailing "\r" from each line
+// so CRLF inputs behave the same as LF.
+func splitLines(raw string) []string {
+	lines := strings.Split(raw, "\n")
+	for i := range lines {
+		lines[i] = strings.TrimRight(lines[i], "\r")
+	}
+	return lines
+}
+
+// findFencedBlocks returns all fenced code blocks in lines, in document
+// order. A fence is three backticks at the start of a line (optionally
+// with an info-string like `json`), and the closing fence is three
+// backticks at the start of a line. The fence-open line and the
+// fence-close line are excluded from the body; the close-line index is
+// preserved so callers can verify what (if anything) follows it.
 //
 // Implemented by hand instead of regexp so the line-anchoring is precise
 // across CRLF and trailing-whitespace edge cases. Backticks appearing
 // mid-line (e.g. inside a quoted string) are correctly ignored — they
 // never start with column 0 of a line, so they cannot match a fence.
-func findFencedBlocks(raw string) []string {
-	var blocks []string
-	lines := strings.Split(raw, "\n")
+func findFencedBlocks(lines []string) []fencedBlock {
+	var blocks []fencedBlock
 	i := 0
 	for i < len(lines) {
-		line := strings.TrimRight(lines[i], "\r")
-		if !isFenceOpen(line) {
+		lang, ok := fenceOpenLang(lines[i])
+		if !ok {
 			i++
 			continue
 		}
 		start := i + 1
 		j := start
 		for j < len(lines) {
-			inner := strings.TrimRight(lines[j], "\r")
-			if inner == "```" {
-				blocks = append(blocks, strings.Join(lines[start:j], "\n"))
+			if lines[j] == "```" {
+				blocks = append(blocks, fencedBlock{
+					lang:     lang,
+					body:     strings.Join(lines[start:j], "\n"),
+					closeIdx: j,
+				})
 				i = j + 1
 				break
 			}
@@ -136,14 +192,16 @@ func findFencedBlocks(raw string) []string {
 	return blocks
 }
 
-// isFenceOpen reports whether line is an opening fence: exactly three
-// backticks optionally followed by an info-string of [a-zA-Z0-9_-]
-// characters and nothing else. The strict info-string charset rejects
-// unusual variants ("``` json", trailing spaces) so the parser's notion
-// of a fence matches what conventional markdown renderers consider one.
-func isFenceOpen(line string) bool {
+// fenceOpenLang reports whether line is an opening fence and, if so,
+// returns its info-string (the optional language tag, e.g. "json", or
+// "" for an untagged fence). A valid opener is exactly three backticks
+// optionally followed by an info-string of [a-zA-Z0-9_-] characters and
+// nothing else. The strict info-string charset rejects unusual variants
+// ("``` json", trailing spaces) so the parser's notion of a fence
+// matches what conventional markdown renderers consider one.
+func fenceOpenLang(line string) (string, bool) {
 	if !strings.HasPrefix(line, "```") {
-		return false
+		return "", false
 	}
 	rest := line[3:]
 	for _, r := range rest {
@@ -153,8 +211,8 @@ func isFenceOpen(line string) bool {
 		case r >= '0' && r <= '9':
 		case r == '_' || r == '-':
 		default:
-			return false
+			return "", false
 		}
 	}
-	return true
+	return rest, true
 }

--- a/pkg/debate/extract_test.go
+++ b/pkg/debate/extract_test.go
@@ -1,0 +1,213 @@
+package debate
+
+import "testing"
+
+func TestExtractAnswer(t *testing.T) {
+	cases := []struct {
+		name       string
+		raw        string
+		wantStatus ExtractStatus
+		wantAnswer string
+	}{
+		{
+			name: "happy path: simple json block",
+			raw: "Some prose discussing peer A.\n\n" +
+				"```json\n" +
+				`{"answer": "The capital of France is Paris."}` + "\n" +
+				"```\n",
+			wantStatus: ExtractOK,
+			wantAnswer: "The capital of France is Paris.",
+		},
+		{
+			name: "happy path: json with citations array is ignored",
+			raw: "prose\n\n" +
+				"```json\n" +
+				`{"answer": "Use Go modules.", "citations": ["https://go.dev/blog/using-go-modules", "https://go.dev/ref/mod"]}` + "\n" +
+				"```\n",
+			wantStatus: ExtractOK,
+			wantAnswer: "Use Go modules.",
+		},
+		{
+			name: "happy path: leading and trailing whitespace inside answer is trimmed",
+			raw: "prose\n\n" +
+				"```json\n" +
+				`{"answer": "  surrounded by spaces  \n"}` + "\n" +
+				"```\n",
+			wantStatus: ExtractOK,
+			wantAnswer: "surrounded by spaces",
+		},
+		{
+			name: "happy path: generic fence without language tag",
+			raw: "prose\n\n" +
+				"```\n" +
+				`{"answer": "no language tag is fine"}` + "\n" +
+				"```\n",
+			wantStatus: ExtractOK,
+			wantAnswer: "no language tag is fine",
+		},
+		{
+			name: "multiple json blocks: extracts the LAST one",
+			raw: "first block (decoy):\n\n" +
+				"```json\n" +
+				`{"answer": "first decoy"}` + "\n" +
+				"```\n\n" +
+				"more prose\n\n" +
+				"```json\n" +
+				`{"answer": "real published answer"}` + "\n" +
+				"```\n",
+			wantStatus: ExtractOK,
+			wantAnswer: "real published answer",
+		},
+		{
+			name:       "no fence: bare json at end of text is rejected",
+			raw:        `Here is my answer: {"answer": "do not extract"}`,
+			wantStatus: ExtractNoJSONBlock,
+			wantAnswer: "",
+		},
+		{
+			name:       "empty input",
+			raw:        "",
+			wantStatus: ExtractNoJSONBlock,
+			wantAnswer: "",
+		},
+		{
+			name: "malformed json inside fences",
+			raw: "prose\n\n" +
+				"```json\n" +
+				`{"answer": "missing closing brace"` + "\n" +
+				"```\n",
+			wantStatus: ExtractInvalidJSON,
+			wantAnswer: "",
+		},
+		{
+			name: "json missing answer key",
+			raw: "prose\n\n" +
+				"```json\n" +
+				`{"citations": ["https://example.com"]}` + "\n" +
+				"```\n",
+			wantStatus: ExtractMissingAnswer,
+			wantAnswer: "",
+		},
+		{
+			name: "json with answer empty string",
+			raw: "prose\n\n" +
+				"```json\n" +
+				`{"answer": ""}` + "\n" +
+				"```\n",
+			wantStatus: ExtractEmptyAnswer,
+			wantAnswer: "",
+		},
+		{
+			name: "json with answer only whitespace",
+			raw: "prose\n\n" +
+				"```json\n" +
+				`{"answer": "   \n\t  "}` + "\n" +
+				"```\n",
+			wantStatus: ExtractEmptyAnswer,
+			wantAnswer: "",
+		},
+		{
+			name: "json with answer null",
+			raw: "prose\n\n" +
+				"```json\n" +
+				`{"answer": null}` + "\n" +
+				"```\n",
+			wantStatus: ExtractMissingAnswer,
+			wantAnswer: "",
+		},
+		{
+			name: "json with answer as a number",
+			raw: "prose\n\n" +
+				"```json\n" +
+				`{"answer": 42}` + "\n" +
+				"```\n",
+			wantStatus: ExtractMissingAnswer,
+			wantAnswer: "",
+		},
+		{
+			name: "json with answer as an array",
+			raw: "prose\n\n" +
+				"```json\n" +
+				`{"answer": ["one", "two"]}` + "\n" +
+				"```\n",
+			wantStatus: ExtractMissingAnswer,
+			wantAnswer: "",
+		},
+		{
+			name: "json with answer as an object",
+			raw: "prose\n\n" +
+				"```json\n" +
+				`{"answer": {"text": "nested"}}` + "\n" +
+				"```\n",
+			wantStatus: ExtractMissingAnswer,
+			wantAnswer: "",
+		},
+		{
+			name: "literal triple-backtick text inside a quoted block, no real fence",
+			raw: "prose mentioning the literal string \"```json\" and \"```\" inline " +
+				"as part of a sentence about formatting requirements, with no real fence anywhere.",
+			wantStatus: ExtractNoJSONBlock,
+			wantAnswer: "",
+		},
+		{
+			name: "happy path: CRLF line endings",
+			raw: "prose\r\n\r\n" +
+				"```json\r\n" +
+				`{"answer": "windows line endings work too"}` + "\r\n" +
+				"```\r\n",
+			wantStatus: ExtractOK,
+			wantAnswer: "windows line endings work too",
+		},
+		{
+			name: "fence with whitespace after backticks is rejected as opener",
+			raw: "prose\n\n" +
+				"``` json\n" +
+				`{"answer": "should not extract"}` + "\n" +
+				"```\n",
+			// "``` json" is not a valid opener; the lone trailing "```"
+			// then starts an unterminated fence, so no block is returned.
+			wantStatus: ExtractNoJSONBlock,
+			wantAnswer: "",
+		},
+		{
+			name: "unterminated fence: no closing backticks",
+			raw: "prose\n\n" +
+				"```json\n" +
+				`{"answer": "never closes"}` + "\n",
+			wantStatus: ExtractNoJSONBlock,
+			wantAnswer: "",
+		},
+		{
+			name: "json answer preserves embedded URLs",
+			raw: "prose\n\n" +
+				"```json\n" +
+				`{"answer": "See https://go.dev for details."}` + "\n" +
+				"```\n",
+			wantStatus: ExtractOK,
+			wantAnswer: "See https://go.dev for details.",
+		},
+		{
+			name: "two consecutive fences with prose between, last wins",
+			raw: "```\n" +
+				`{"answer": "first"}` + "\n" +
+				"```\n" +
+				"```json\n" +
+				`{"answer": "second"}` + "\n" +
+				"```\n",
+			wantStatus: ExtractOK,
+			wantAnswer: "second",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotAnswer, gotStatus := ExtractAnswer(tc.raw)
+			if gotStatus != tc.wantStatus {
+				t.Fatalf("status = %v, want %v (answer=%q)", gotStatus, tc.wantStatus, gotAnswer)
+			}
+			if gotAnswer != tc.wantAnswer {
+				t.Fatalf("answer = %q, want %q", gotAnswer, tc.wantAnswer)
+			}
+		})
+	}
+}

--- a/pkg/debate/extract_test.go
+++ b/pkg/debate/extract_test.go
@@ -211,3 +211,29 @@ func TestExtractAnswer(t *testing.T) {
 		})
 	}
 }
+
+// TestExtractStatus_VerdictStatus pins the wire-format strings the
+// orchestrator writes into verdict.json's answer_extraction.status field
+// (ADR-0014). Every ExtractStatus value must map to a stable, jq-probable
+// string ("ok" or "fallback_*"); a defensive default catches future enum
+// extensions that forget to update the table.
+func TestExtractStatus_VerdictStatus(t *testing.T) {
+	cases := []struct {
+		status ExtractStatus
+		want   string
+	}{
+		{status: ExtractOK, want: "ok"},
+		{status: ExtractNoJSONBlock, want: "fallback_no_json"},
+		{status: ExtractInvalidJSON, want: "fallback_invalid_json"},
+		{status: ExtractMissingAnswer, want: "fallback_missing_answer"},
+		{status: ExtractEmptyAnswer, want: "fallback_empty_answer"},
+		{status: ExtractStatus(99), want: "fallback_unknown"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			if got := tc.status.VerdictStatus(); got != tc.want {
+				t.Errorf("(%v).VerdictStatus() = %q, want %q", tc.status, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/debate/extract_test.go
+++ b/pkg/debate/extract_test.go
@@ -197,6 +197,86 @@ func TestExtractAnswer(t *testing.T) {
 			wantStatus: ExtractOK,
 			wantAnswer: "second",
 		},
+		{
+			// Regression: a winner whose only fenced block is a non-JSON
+			// language (here ```bash) must report fallback_no_json so the
+			// parse-success telemetry is not corrupted by classifying
+			// "no JSON tail at all" as "JSON tail that failed to parse".
+			name: "non-json language fence and nothing else: fallback_no_json",
+			raw: "prose discussing the answer.\n\n" +
+				"```bash\n" +
+				`echo "hello"` + "\n" +
+				"```\n",
+			wantStatus: ExtractNoJSONBlock,
+			wantAnswer: "",
+		},
+		{
+			// A non-JSON language block followed later by a real JSON
+			// block must still extract — filtering must not skip the
+			// real block, only the foreign-language one.
+			name: "bash block then json block: extracts the json block",
+			raw: "```bash\n" +
+				`echo "decoy"` + "\n" +
+				"```\n\n" +
+				"```json\n" +
+				`{"answer": "real published answer"}` + "\n" +
+				"```\n",
+			wantStatus: ExtractOK,
+			wantAnswer: "real published answer",
+		},
+		{
+			// Generic fence whose body is plainly not JSON (does not
+			// start with `{`) must be treated as no candidate, not a
+			// failed JSON parse.
+			name: "untagged fence with non-json body: fallback_no_json",
+			raw: "```\n" +
+				`echo "not json"` + "\n" +
+				"```\n",
+			wantStatus: ExtractNoJSONBlock,
+			wantAnswer: "",
+		},
+		{
+			// Tail-enforcement: peer-aware.md requires the JSON block
+			// to be the last content. A draft JSON earlier in the
+			// response followed by a non-JSON code fence must NOT be
+			// extracted — that would publish stale draft text and
+			// inflate parse-success telemetry.
+			name: "json block followed by bash fence: fallback_no_json",
+			raw: "```json\n" +
+				`{"answer": "draft, not final"}` + "\n" +
+				"```\n\n" +
+				"and here is the actual final answer in shell:\n\n" +
+				"```bash\n" +
+				`echo "final"` + "\n" +
+				"```\n",
+			wantStatus: ExtractNoJSONBlock,
+			wantAnswer: "",
+		},
+		{
+			// Tail-enforcement: prose after the closing fence also
+			// disqualifies the block. The contract is "nothing after
+			// the closing fence" (peer-aware.md), not "last fenced
+			// thing wins regardless of what follows".
+			name: "json block followed by trailing prose: fallback_no_json",
+			raw: "```json\n" +
+				`{"answer": "draft, not final"}` + "\n" +
+				"```\n\n" +
+				"actually, on reflection, my real answer is different.\n",
+			wantStatus: ExtractNoJSONBlock,
+			wantAnswer: "",
+		},
+		{
+			// Trailing whitespace (blank lines, indentation) after the
+			// closing fence is fine — the prompt allows it implicitly
+			// and many CLIs tack on trailing newlines.
+			name: "json block followed only by whitespace: extracts ok",
+			raw: "prose\n\n" +
+				"```json\n" +
+				`{"answer": "trailing whitespace is fine"}` + "\n" +
+				"```\n\n   \n\t\n",
+			wantStatus: ExtractOK,
+			wantAnswer: "trailing whitespace is fine",
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/debate/reporter.go
+++ b/pkg/debate/reporter.go
@@ -137,15 +137,6 @@ func reportRoundExpert(rep Reporter, round int, ex LabeledExpert, r *RoundOutput
 	})
 }
 
-// reportBallot is the deferred fire-point used by runOneBallot. Same
-// pointer-to-result pattern as reportRoundExpert so the defer reflects the
-// final outcome (success, discarded, or rate-limited). RunBallot normalizes
-// a nil BallotConfig.Reporter to NopReporter{} before fanning out, so this
-// callee can assume rep is always non-nil. realNames is a precomputed
-// label->Role.Name map for the active cohort: built once in RunBallot
-// against the same defensive copy used to derive `active`, so reporting
-// resolves b.VotedFor in O(1) and never reads through the unsorted shared
-// cfg.Experts slice header.
 // reportExtraction is the fire-point used by SelectOutput on the unique-
 // winner path, after output.md has been written. The renderer surfaces
 // the ExtractOK / fallback discriminator so the operator can audit the
@@ -163,6 +154,15 @@ func reportExtraction(rep Reporter, label, realName string, status ExtractStatus
 	})
 }
 
+// reportBallot is the deferred fire-point used by runOneBallot. Same
+// pointer-to-result pattern as reportRoundExpert so the defer reflects the
+// final outcome (success, discarded, or rate-limited). RunBallot normalizes
+// a nil BallotConfig.Reporter to NopReporter{} before fanning out, so this
+// callee can assume rep is always non-nil. realNames is a precomputed
+// label->Role.Name map for the active cohort: built once in RunBallot
+// against the same defensive copy used to derive `active`, so reporting
+// resolves b.VotedFor in O(1) and never reads through the unsorted shared
+// cfg.Experts slice header.
 func reportBallot(rep Reporter, ex LabeledExpert, realNames map[string]string, b *Ballot, body []byte, resumed bool) {
 	var votedForRealName string
 	if b.VotedFor != "" {

--- a/pkg/debate/reporter.go
+++ b/pkg/debate/reporter.go
@@ -27,17 +27,19 @@ type Reporter interface {
 	OnStageDone(StageEvent)
 }
 
-// StageEvent is the per-stage payload. Kind discriminates the two event
-// kinds ("round-expert" and "ballot"); within "round-expert", Round
-// distinguishes the round-1 and round-2 shapes. Consumers switch on Kind
-// and read only the fields relevant to that shape.
+// StageEvent is the per-stage payload. Kind discriminates the three event
+// kinds ("round-expert", "ballot", "extraction"); within "round-expert",
+// Round distinguishes the round-1 and round-2 shapes. Consumers switch on
+// Kind and read only the fields relevant to that shape.
 //
 // Body is the raw subprocess stdout (output.md or votes/<label>.txt) the
-// debate package already loaded for the forgery scan. It carries through
-// untrusted LLM bytes — consumers should pipe it through stripControlBytes
-// (or equivalent) before writing to a terminal.
+// debate package already loaded for the forgery scan. For extraction
+// events it carries the bytes that were written to output.md (the
+// extracted answer on ExtractOK; the raw R2 on any fallback). It carries
+// through untrusted LLM bytes — consumers should pipe it through
+// stripControlBytes (or equivalent) before writing to a terminal.
 type StageEvent struct {
-	// Kind is "round-expert" or "ballot".
+	// Kind is "round-expert", "ballot", or "extraction".
 	Kind string
 
 	// Round is 1 or 2 for round-expert events; 0 for ballot events.
@@ -95,6 +97,14 @@ type StageEvent struct {
 	// .done marker (D14 resume path) rather than re-spawned. Body is still
 	// populated (read from disk); Duration is zero.
 	Resumed bool
+
+	// ExtractStatus is the JSON-tail extraction outcome (ADR-0014) for
+	// Kind == "extraction" events. ExtractOK indicates the published
+	// answer in Body is the extracted JSON `answer` field; any other
+	// value indicates the caller fell back to writing the raw R2 body
+	// verbatim. Zero (ExtractOK) on non-extraction events — consumers
+	// switch on Kind first, so the alias is harmless.
+	ExtractStatus ExtractStatus
 }
 
 // NopReporter is the default when --verbose is off. Debate code can call
@@ -136,6 +146,23 @@ func reportRoundExpert(rep Reporter, round int, ex LabeledExpert, r *RoundOutput
 // against the same defensive copy used to derive `active`, so reporting
 // resolves b.VotedFor in O(1) and never reads through the unsorted shared
 // cfg.Experts slice header.
+// reportExtraction is the fire-point used by SelectOutput on the unique-
+// winner path, after output.md has been written. The renderer surfaces
+// the ExtractOK / fallback discriminator so the operator can audit the
+// JSON-tail compliance rate live, without re-reading verdict.json. Body
+// carries the bytes that landed in output.md so the renderer can report
+// "N chars" without recomputing them. The caller is expected to have
+// already normalized rep to NopReporter when --verbose is off.
+func reportExtraction(rep Reporter, label, realName string, status ExtractStatus, published string) {
+	rep.OnStageDone(StageEvent{
+		Kind:          "extraction",
+		Label:         label,
+		RealName:      realName,
+		Body:          []byte(published),
+		ExtractStatus: status,
+	})
+}
+
 func reportBallot(rep Reporter, ex LabeledExpert, realNames map[string]string, b *Ballot, body []byte, resumed bool) {
 	var votedForRealName string
 	if b.VotedFor != "" {

--- a/pkg/debate/reporter_test.go
+++ b/pkg/debate/reporter_test.go
@@ -237,4 +237,116 @@ func TestReporter_NilTolerated(t *testing.T) {
 	if _, err := RunBallot(context.Background(), bcfg, "q?", "agg"); err != nil {
 		t.Fatalf("RunBallot with nil Reporter: %v", err)
 	}
+
+	// SelectOutput nil-Reporter path: must not panic when --verbose is off.
+	r2 := []RoundOutput{{Label: "A", Name: "expert_a", Participation: "ok", Body: "body\n"}}
+	if _, err := SelectOutput(s, TallyResult{Votes: map[string]int{"A": 1}, Winner: "A"}, r2, nil); err != nil {
+		t.Fatalf("SelectOutput with nil Reporter: %v", err)
+	}
+}
+
+// TestReporter_SelectOutput_FiresExtractionOnUniqueWinner pins that
+// SelectOutput emits exactly one Kind == "extraction" event on the
+// unique-winner path, with the winner's label + real name and the
+// JSON-tail extraction status. The event is what cmd/council renders
+// to the live verbose stream (ADR-0014 Task 5).
+func TestReporter_SelectOutput_FiresExtractionOnUniqueWinner(t *testing.T) {
+	s, _, _ := setupRoundTest(t, "abcd1234abcd1234", &testExec{
+		name: testExecName,
+		fn:   func(ctx context.Context, req executor.Request, _ int) (string, error) { return "", nil },
+	})
+	winnerBody := "prose body.\n\n```json\n{\"answer\": \"Clean.\"}\n```\n"
+	r2 := []RoundOutput{
+		{Label: "A", Name: "expert_a", Participation: "ok", Body: "A\n"},
+		{Label: "B", Name: "expert_b", Participation: "ok", Body: winnerBody},
+	}
+	result := TallyResult{Votes: map[string]int{"A": 0, "B": 2}, Winner: "B"}
+	rep := &recordingReporter{}
+	if _, err := SelectOutput(s, result, r2, rep); err != nil {
+		t.Fatalf("SelectOutput: %v", err)
+	}
+
+	events := rep.snapshot()
+	if got, want := len(events), 1; got != want {
+		t.Fatalf("len(events) = %d, want %d", got, want)
+	}
+	ev := events[0]
+	if ev.Kind != "extraction" {
+		t.Errorf("Kind = %q, want extraction", ev.Kind)
+	}
+	if ev.Label != "B" {
+		t.Errorf("Label = %q, want B", ev.Label)
+	}
+	if ev.RealName != "expert_b" {
+		t.Errorf("RealName = %q, want expert_b", ev.RealName)
+	}
+	if ev.ExtractStatus != ExtractOK {
+		t.Errorf("ExtractStatus = %v, want ExtractOK", ev.ExtractStatus)
+	}
+	if string(ev.Body) != "Clean.\n" {
+		t.Errorf("Body = %q, want \"Clean.\\n\" (extracted answer)", string(ev.Body))
+	}
+}
+
+// TestReporter_SelectOutput_FiresExtractionOnFallback pins the parallel
+// contract on the fail-closed path: the event still fires, with Body
+// carrying the raw R2 bytes (what landed in output.md) and ExtractStatus
+// reflecting the fallback reason.
+func TestReporter_SelectOutput_FiresExtractionOnFallback(t *testing.T) {
+	s, _, _ := setupRoundTest(t, "1234abcd1234abcd", &testExec{
+		name: testExecName,
+		fn:   func(ctx context.Context, req executor.Request, _ int) (string, error) { return "", nil },
+	})
+	rawBody := "raw R2 with no JSON tail at all.\n"
+	r2 := []RoundOutput{
+		{Label: "A", Name: "expert_a", Participation: "ok", Body: rawBody},
+	}
+	result := TallyResult{Votes: map[string]int{"A": 1}, Winner: "A"}
+	rep := &recordingReporter{}
+	if _, err := SelectOutput(s, result, r2, rep); err != nil {
+		t.Fatalf("SelectOutput: %v", err)
+	}
+
+	events := rep.snapshot()
+	if got, want := len(events), 1; got != want {
+		t.Fatalf("len(events) = %d, want %d", got, want)
+	}
+	ev := events[0]
+	if ev.Kind != "extraction" {
+		t.Errorf("Kind = %q, want extraction", ev.Kind)
+	}
+	if ev.ExtractStatus != ExtractNoJSONBlock {
+		t.Errorf("ExtractStatus = %v, want ExtractNoJSONBlock", ev.ExtractStatus)
+	}
+	if string(ev.Body) != rawBody {
+		t.Errorf("Body = %q, want raw R2 body verbatim", string(ev.Body))
+	}
+}
+
+// TestReporter_SelectOutput_NoExtractionEventOnTie pins that ties never
+// emit an extraction event — extraction is unique-winner-only, so a tie
+// stage produces zero extraction events.
+func TestReporter_SelectOutput_NoExtractionEventOnTie(t *testing.T) {
+	s, _, _ := setupRoundTest(t, "feedfacefeedface", &testExec{
+		name: testExecName,
+		fn:   func(ctx context.Context, req executor.Request, _ int) (string, error) { return "", nil },
+	})
+	r2 := []RoundOutput{
+		{Label: "A", Name: "expert_a", Participation: "ok", Body: "A\n"},
+		{Label: "B", Name: "expert_b", Participation: "ok", Body: "B\n"},
+	}
+	result := TallyResult{
+		Votes:          map[string]int{"A": 1, "B": 1},
+		TiedCandidates: []string{"A", "B"},
+	}
+	rep := &recordingReporter{}
+	if _, err := SelectOutput(s, result, r2, rep); err != nil {
+		t.Fatalf("SelectOutput: %v", err)
+	}
+
+	for _, ev := range rep.snapshot() {
+		if ev.Kind == "extraction" {
+			t.Errorf("unexpected extraction event on tie: %+v", ev)
+		}
+	}
 }

--- a/pkg/debate/vote.go
+++ b/pkg/debate/vote.go
@@ -370,9 +370,18 @@ type ExtractionOutcome struct {
 //
 // rounds/r2/<label>.txt is never touched: that file is the verbatim audit
 // record of what the expert produced.
-func SelectOutput(s *session.Session, result TallyResult, r2 []RoundOutput) (ExtractionOutcome, error) {
+//
+// reporter receives one OnStageDone call with Kind == "extraction" on the
+// unique-winner path AFTER output.md has been written, so the live
+// verbose stream can surface JSON-tail compliance per session. Nil is
+// normalized to NopReporter so callers that don't need streaming (most
+// tests) can pass nil.
+func SelectOutput(s *session.Session, result TallyResult, r2 []RoundOutput, reporter Reporter) (ExtractionOutcome, error) {
 	if s == nil {
 		return ExtractionOutcome{}, fmt.Errorf("SelectOutput: session required")
+	}
+	if reporter == nil {
+		reporter = NopReporter{}
 	}
 	if err := writeTallyJSON(s, result); err != nil {
 		return ExtractionOutcome{}, err
@@ -413,6 +422,7 @@ func SelectOutput(s *session.Session, result TallyResult, r2 []RoundOutput) (Ext
 		if err := os.WriteFile(path, []byte(published), 0o644); err != nil {
 			return ExtractionOutcome{}, fmt.Errorf("SelectOutput: write %s: %w", path, err)
 		}
+		reportExtraction(reporter, result.Winner, r.Name, status, published)
 		return ExtractionOutcome{WinnerLabel: result.Winner, Status: status, Answer: published}, nil
 	}
 

--- a/pkg/debate/vote.go
+++ b/pkg/debate/vote.go
@@ -345,22 +345,37 @@ func Tally(ballots []Ballot, activeLabels []string) TallyResult {
 	return result
 }
 
+// ExtractionOutcome reports what SelectOutput wrote to output.md on the
+// unique-winner path. WinnerLabel is "" on ties: there is no single
+// published answer to report, and Status / Answer are zero-valued.
+//
+// On the unique-winner path, Status is the result of running ExtractAnswer
+// over the winner's R2 body, and Answer is the exact bytes written to
+// output.md — the extracted JSON-tail answer when Status == ExtractOK,
+// otherwise the raw R2 body (the fail-closed fallback per ADR-0014).
+type ExtractionOutcome struct {
+	WinnerLabel string
+	Status      ExtractStatus
+	Answer      string
+}
+
 // SelectOutput finalises the voting stage on disk:
 //  1. writes voting/tally.json (votes + ballots + winner/tied fields)
-//  2. copies the winner's R2 body to session root output.md (unique winner)
-//     OR copies each tied candidate's R2 body to output-<label>.md (tie).
+//  2. on a unique winner, runs ExtractAnswer over the winner's R2 body and
+//     writes the clean JSON-tail answer to session-root output.md; on any
+//     extraction failure, falls back to writing the raw R2 body verbatim
+//     (ADR-0014 fail-closed → today's behavior).
+//  3. on a tie, copies each tied candidate's R2 body verbatim to
+//     output-<label>.md. Extraction is unique-winner-only.
 //
-// Copying the R2 body rather than the aggregate preserves the verbatim
-// expert text per D8 ("R2 output is copied verbatim to output.md"). The
-// source of truth for each label is r2[].Body, not rounds/2/aggregate.md,
-// because carried entries hold the R1 body and the aggregate formatting
-// includes nonce fences the operator should not see.
-func SelectOutput(s *session.Session, result TallyResult, r2 []RoundOutput) error {
+// rounds/r2/<label>.txt is never touched: that file is the verbatim audit
+// record of what the expert produced.
+func SelectOutput(s *session.Session, result TallyResult, r2 []RoundOutput) (ExtractionOutcome, error) {
 	if s == nil {
-		return fmt.Errorf("SelectOutput: session required")
+		return ExtractionOutcome{}, fmt.Errorf("SelectOutput: session required")
 	}
 	if err := writeTallyJSON(s, result); err != nil {
-		return err
+		return ExtractionOutcome{}, err
 	}
 
 	r2ByLabel := make(map[string]*RoundOutput, len(r2))
@@ -375,32 +390,43 @@ func SelectOutput(s *session.Session, result TallyResult, r2 []RoundOutput) erro
 	// every prior output*.md in the session root before writing the
 	// selected one(s) so the artifacts on disk always match tally.json.
 	if err := cleanOutputs(s); err != nil {
-		return err
+		return ExtractionOutcome{}, err
 	}
 
 	if result.Winner != "" {
 		r := r2ByLabel[result.Winner]
 		if r == nil {
-			return fmt.Errorf("SelectOutput: winner label %q has no R2 output", result.Winner)
+			return ExtractionOutcome{}, fmt.Errorf("SelectOutput: winner label %q has no R2 output", result.Winner)
+		}
+		extracted, status := ExtractAnswer(r.Body)
+		var published string
+		if status == ExtractOK {
+			// Plan §Task3: write extracted answer with a single trailing
+			// newline. ExtractAnswer trims surrounding whitespace, so we
+			// re-add exactly one \n; matches the raw-R2 path's convention
+			// of ending output.md with a newline.
+			published = extracted + "\n"
+		} else {
+			published = r.Body
 		}
 		path := filepath.Join(s.Path, "output.md")
-		if err := os.WriteFile(path, []byte(r.Body), 0o644); err != nil {
-			return fmt.Errorf("SelectOutput: write %s: %w", path, err)
+		if err := os.WriteFile(path, []byte(published), 0o644); err != nil {
+			return ExtractionOutcome{}, fmt.Errorf("SelectOutput: write %s: %w", path, err)
 		}
-		return nil
+		return ExtractionOutcome{WinnerLabel: result.Winner, Status: status, Answer: published}, nil
 	}
 
 	for _, label := range result.TiedCandidates {
 		r := r2ByLabel[label]
 		if r == nil {
-			return fmt.Errorf("SelectOutput: tied label %q has no R2 output", label)
+			return ExtractionOutcome{}, fmt.Errorf("SelectOutput: tied label %q has no R2 output", label)
 		}
 		path := filepath.Join(s.Path, "output-"+label+".md")
 		if err := os.WriteFile(path, []byte(r.Body), 0o644); err != nil {
-			return fmt.Errorf("SelectOutput: write %s: %w", path, err)
+			return ExtractionOutcome{}, fmt.Errorf("SelectOutput: write %s: %w", path, err)
 		}
 	}
-	return nil
+	return ExtractionOutcome{}, nil
 }
 
 // cleanOutputs removes the session-root output.md and every output-*.md

--- a/pkg/debate/vote.go
+++ b/pkg/debate/vote.go
@@ -368,8 +368,8 @@ type ExtractionOutcome struct {
 //  3. on a tie, copies each tied candidate's R2 body verbatim to
 //     output-<label>.md. Extraction is unique-winner-only.
 //
-// rounds/r2/<label>.txt is never touched: that file is the verbatim audit
-// record of what the expert produced.
+// rounds/2/experts/<label>/output.md is never touched: that file is the
+// verbatim audit record of what the expert produced.
 //
 // reporter receives one OnStageDone call with Kind == "extraction" on the
 // unique-winner path AFTER output.md has been written, so the live

--- a/pkg/debate/vote_test.go
+++ b/pkg/debate/vote_test.go
@@ -613,8 +613,18 @@ func TestSelectOutput_UniqueWinner_CopiesToOutputMd(t *testing.T) {
 		Winner:  "B",
 		Ballots: []Ballot{{VoterLabel: "A", VotedFor: "B"}, {VoterLabel: "B", VotedFor: "B"}, {VoterLabel: "C", VotedFor: "B"}},
 	}
-	if err := SelectOutput(s, result, r2); err != nil {
+	outcome, err := SelectOutput(s, result, r2)
+	if err != nil {
 		t.Fatalf("SelectOutput: %v", err)
+	}
+	if outcome.WinnerLabel != "B" {
+		t.Errorf("outcome.WinnerLabel = %q, want B", outcome.WinnerLabel)
+	}
+	if outcome.Status != ExtractNoJSONBlock {
+		t.Errorf("outcome.Status = %v, want ExtractNoJSONBlock (raw body has no JSON tail)", outcome.Status)
+	}
+	if outcome.Answer != "B final answer\n" {
+		t.Errorf("outcome.Answer = %q, want raw body", outcome.Answer)
 	}
 	body, err := os.ReadFile(filepath.Join(s.Path, "output.md"))
 	if err != nil {
@@ -676,8 +686,15 @@ func TestSelectOutput_ThreeWayTie_CopiesPerLabel(t *testing.T) {
 			{VoterLabel: "C", VotedFor: "C"},
 		},
 	}
-	if err := SelectOutput(s, result, r2); err != nil {
+	outcome, err := SelectOutput(s, result, r2)
+	if err != nil {
 		t.Fatalf("SelectOutput: %v", err)
+	}
+	if outcome.WinnerLabel != "" {
+		t.Errorf("outcome.WinnerLabel = %q, want empty on tie (no extraction performed)", outcome.WinnerLabel)
+	}
+	if outcome.Answer != "" {
+		t.Errorf("outcome.Answer = %q, want empty on tie", outcome.Answer)
 	}
 	for _, l := range []string{"A", "B", "C"} {
 		body, err := os.ReadFile(filepath.Join(s.Path, "output-"+l+".md"))
@@ -711,7 +728,7 @@ func TestSelectOutput_TwoWayTie_N2(t *testing.T) {
 			{VoterLabel: "B", VotedFor: "B"},
 		},
 	}
-	if err := SelectOutput(s, result, r2); err != nil {
+	if _, err := SelectOutput(s, result, r2); err != nil {
 		t.Fatalf("SelectOutput: %v", err)
 	}
 	for _, l := range []string{"A", "B"} {
@@ -746,7 +763,7 @@ func TestSelectOutput_Resume_TieToWinner_CleansStaleTiedOutputs(t *testing.T) {
 		Votes:  map[string]int{"A": 2, "B": 0},
 		Winner: "A",
 	}
-	if err := SelectOutput(s, result, r2); err != nil {
+	if _, err := SelectOutput(s, result, r2); err != nil {
 		t.Fatalf("SelectOutput: %v", err)
 	}
 	body, err := os.ReadFile(filepath.Join(s.Path, "output.md"))
@@ -783,7 +800,7 @@ func TestSelectOutput_Resume_WinnerToTie_CleansStaleOutputMd(t *testing.T) {
 		Votes:          map[string]int{"A": 1, "B": 1},
 		TiedCandidates: []string{"A", "B"},
 	}
-	if err := SelectOutput(s, result, r2); err != nil {
+	if _, err := SelectOutput(s, result, r2); err != nil {
 		t.Fatalf("SelectOutput: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(s.Path, "output.md")); !os.IsNotExist(err) {
@@ -824,7 +841,7 @@ func TestSelectOutput_Resume_TiedSetShrinks_CleansDroppedLabel(t *testing.T) {
 		Votes:          map[string]int{"A": 1, "B": 1, "C": 0},
 		TiedCandidates: []string{"A", "B"},
 	}
-	if err := SelectOutput(s, result, r2); err != nil {
+	if _, err := SelectOutput(s, result, r2); err != nil {
 		t.Fatalf("SelectOutput: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(s.Path, "output-C.md")); !os.IsNotExist(err) {
@@ -881,14 +898,177 @@ func TestSelectOutput_MissingR2ForWinner_Error(t *testing.T) {
 		fn:   func(ctx context.Context, req executor.Request, _ int) (string, error) { return "", nil },
 	})
 	result := TallyResult{Winner: "X", Votes: map[string]int{"X": 1}}
-	if err := SelectOutput(s, result, []RoundOutput{{Label: "A"}}); err == nil {
+	if _, err := SelectOutput(s, result, []RoundOutput{{Label: "A"}}); err == nil {
 		t.Fatal("expected error when winner label has no R2 output")
 	}
 }
 
 func TestSelectOutput_NilSession(t *testing.T) {
-	if err := SelectOutput(nil, TallyResult{Winner: "A"}, []RoundOutput{{Label: "A", Body: "x"}}); err == nil {
+	if _, err := SelectOutput(nil, TallyResult{Winner: "A"}, []RoundOutput{{Label: "A", Body: "x"}}); err == nil {
 		t.Fatal("expected error for nil session")
+	}
+}
+
+// TestSelectOutput_UniqueWinner_ExtractsCleanAnswer covers the happy path of
+// ADR-0014: the winner's R2 body ends with a fenced JSON block carrying a
+// clean `answer`, so output.md must contain only that extracted answer (with
+// a single trailing newline) — not the prose preceding the JSON tail.
+// outcome.Status reports ExtractOK and outcome.Answer mirrors output.md so
+// the orchestrator can publish the same bytes to verdict.answer.
+func TestSelectOutput_UniqueWinner_ExtractsCleanAnswer(t *testing.T) {
+	s, _, _ := setupRoundTest(t, "1111ffff2222eeee", &testExec{
+		name: testExecName,
+		fn:   func(ctx context.Context, req executor.Request, _ int) (string, error) { return "", nil },
+	})
+	winnerBody := "Эксперт A корректно указывает X. Эксперт C справедливо вводит Y.\n" +
+		"Полный разбор с упоминанием коллег.\n\n" +
+		"```json\n" +
+		"{\"answer\": \"Clean standalone answer.\", \"citations\": [\"https://example.com\"]}\n" +
+		"```\n"
+	r2 := []RoundOutput{
+		{Label: "A", Participation: "ok", Body: "A body\n"},
+		{Label: "B", Participation: "ok", Body: winnerBody},
+		{Label: "C", Participation: "ok", Body: "C body\n"},
+	}
+	result := TallyResult{
+		Votes:  map[string]int{"A": 0, "B": 3, "C": 0},
+		Winner: "B",
+	}
+	outcome, err := SelectOutput(s, result, r2)
+	if err != nil {
+		t.Fatalf("SelectOutput: %v", err)
+	}
+	if outcome.Status != ExtractOK {
+		t.Errorf("outcome.Status = %v, want ExtractOK", outcome.Status)
+	}
+	if outcome.WinnerLabel != "B" {
+		t.Errorf("outcome.WinnerLabel = %q, want B", outcome.WinnerLabel)
+	}
+	want := "Clean standalone answer.\n"
+	if outcome.Answer != want {
+		t.Errorf("outcome.Answer = %q, want %q", outcome.Answer, want)
+	}
+	body, err := os.ReadFile(filepath.Join(s.Path, "output.md"))
+	if err != nil {
+		t.Fatalf("read output.md: %v", err)
+	}
+	if string(body) != want {
+		t.Errorf("output.md = %q, want %q", body, want)
+	}
+	if strings.Contains(string(body), "Эксперт") {
+		t.Errorf("output.md still contains peer references: %q", body)
+	}
+	if strings.Contains(string(body), "```") {
+		t.Errorf("output.md still contains JSON fence: %q", body)
+	}
+}
+
+// TestSelectOutput_UniqueWinner_NoJSONTail_FallsBackToRawR2 covers the
+// fail-closed contract: a winner R2 with no fenced JSON block must fall
+// back to the raw body verbatim (today's behavior). outcome.Status carries
+// the discriminator so the orchestrator can record it in verdict.json.
+func TestSelectOutput_UniqueWinner_NoJSONTail_FallsBackToRawR2(t *testing.T) {
+	s, _, _ := setupRoundTest(t, "2222dddd3333cccc", &testExec{
+		name: testExecName,
+		fn:   func(ctx context.Context, req executor.Request, _ int) (string, error) { return "", nil },
+	})
+	winnerBody := "Body with no JSON tail at all.\n"
+	r2 := []RoundOutput{
+		{Label: "A", Participation: "ok", Body: winnerBody},
+	}
+	result := TallyResult{Votes: map[string]int{"A": 1}, Winner: "A"}
+	outcome, err := SelectOutput(s, result, r2)
+	if err != nil {
+		t.Fatalf("SelectOutput: %v", err)
+	}
+	if outcome.Status != ExtractNoJSONBlock {
+		t.Errorf("outcome.Status = %v, want ExtractNoJSONBlock", outcome.Status)
+	}
+	if outcome.Answer != winnerBody {
+		t.Errorf("outcome.Answer = %q, want raw body", outcome.Answer)
+	}
+	body, err := os.ReadFile(filepath.Join(s.Path, "output.md"))
+	if err != nil {
+		t.Fatalf("read output.md: %v", err)
+	}
+	if string(body) != winnerBody {
+		t.Errorf("output.md = %q, want raw body %q", body, winnerBody)
+	}
+}
+
+// TestSelectOutput_UniqueWinner_MalformedJSON_FallsBackToRawR2 is the
+// regression test for the ADR-0014 fail-closed promise: a winner R2 that
+// emits a fenced block whose contents fail to parse as JSON must NOT panic,
+// must NOT corrupt output.md, and must publish the raw R2 body unchanged.
+// outcome.Status reflects ExtractInvalidJSON so the operator can see the
+// failure mode in verdict.json instead of silently degrading to "ok".
+func TestSelectOutput_UniqueWinner_MalformedJSON_FallsBackToRawR2(t *testing.T) {
+	s, _, _ := setupRoundTest(t, "3333bbbb4444aaaa", &testExec{
+		name: testExecName,
+		fn:   func(ctx context.Context, req executor.Request, _ int) (string, error) { return "", nil },
+	})
+	winnerBody := "Prose body.\n\n```json\n{not valid json at all\n```\n"
+	r2 := []RoundOutput{
+		{Label: "A", Participation: "ok", Body: winnerBody},
+	}
+	result := TallyResult{Votes: map[string]int{"A": 1}, Winner: "A"}
+	outcome, err := SelectOutput(s, result, r2)
+	if err != nil {
+		t.Fatalf("SelectOutput: %v", err)
+	}
+	if outcome.Status != ExtractInvalidJSON {
+		t.Errorf("outcome.Status = %v, want ExtractInvalidJSON", outcome.Status)
+	}
+	if outcome.Answer != winnerBody {
+		t.Errorf("outcome.Answer = %q, want raw body", outcome.Answer)
+	}
+	body, err := os.ReadFile(filepath.Join(s.Path, "output.md"))
+	if err != nil {
+		t.Fatalf("read output.md: %v", err)
+	}
+	if string(body) != winnerBody {
+		t.Errorf("output.md = %q, want raw body %q", body, winnerBody)
+	}
+}
+
+// TestSelectOutput_Tie_NoExtractionPerformed pins that ties never run
+// extraction — outcome is the zero value (WinnerLabel empty, Status zero,
+// Answer empty) — so the orchestrator can use a non-empty WinnerLabel as
+// the "extraction happened" signal without misreading a tie's zero Status
+// as ExtractOK.
+func TestSelectOutput_Tie_NoExtractionPerformed(t *testing.T) {
+	s, _, _ := setupRoundTest(t, "4444aaaa5555bbbb", &testExec{
+		name: testExecName,
+		fn:   func(ctx context.Context, req executor.Request, _ int) (string, error) { return "", nil },
+	})
+	winnerBody := "Body.\n\n```json\n{\"answer\": \"clean\"}\n```\n"
+	r2 := []RoundOutput{
+		{Label: "A", Participation: "ok", Body: winnerBody},
+		{Label: "B", Participation: "ok", Body: winnerBody},
+	}
+	result := TallyResult{
+		Votes:          map[string]int{"A": 1, "B": 1},
+		TiedCandidates: []string{"A", "B"},
+	}
+	outcome, err := SelectOutput(s, result, r2)
+	if err != nil {
+		t.Fatalf("SelectOutput: %v", err)
+	}
+	if outcome.WinnerLabel != "" {
+		t.Errorf("outcome.WinnerLabel = %q, want empty on tie", outcome.WinnerLabel)
+	}
+	if outcome.Answer != "" {
+		t.Errorf("outcome.Answer = %q, want empty on tie", outcome.Answer)
+	}
+	// Per-label files contain the verbatim raw body; extraction is unique-winner-only.
+	for _, l := range []string{"A", "B"} {
+		body, err := os.ReadFile(filepath.Join(s.Path, "output-"+l+".md"))
+		if err != nil {
+			t.Fatalf("read output-%s.md: %v", l, err)
+		}
+		if string(body) != winnerBody {
+			t.Errorf("output-%s.md = %q, want raw body verbatim", l, body)
+		}
 	}
 }
 

--- a/pkg/debate/vote_test.go
+++ b/pkg/debate/vote_test.go
@@ -613,7 +613,7 @@ func TestSelectOutput_UniqueWinner_CopiesToOutputMd(t *testing.T) {
 		Winner:  "B",
 		Ballots: []Ballot{{VoterLabel: "A", VotedFor: "B"}, {VoterLabel: "B", VotedFor: "B"}, {VoterLabel: "C", VotedFor: "B"}},
 	}
-	outcome, err := SelectOutput(s, result, r2)
+	outcome, err := SelectOutput(s, result, r2, nil)
 	if err != nil {
 		t.Fatalf("SelectOutput: %v", err)
 	}
@@ -686,7 +686,7 @@ func TestSelectOutput_ThreeWayTie_CopiesPerLabel(t *testing.T) {
 			{VoterLabel: "C", VotedFor: "C"},
 		},
 	}
-	outcome, err := SelectOutput(s, result, r2)
+	outcome, err := SelectOutput(s, result, r2, nil)
 	if err != nil {
 		t.Fatalf("SelectOutput: %v", err)
 	}
@@ -728,7 +728,7 @@ func TestSelectOutput_TwoWayTie_N2(t *testing.T) {
 			{VoterLabel: "B", VotedFor: "B"},
 		},
 	}
-	if _, err := SelectOutput(s, result, r2); err != nil {
+	if _, err := SelectOutput(s, result, r2, nil); err != nil {
 		t.Fatalf("SelectOutput: %v", err)
 	}
 	for _, l := range []string{"A", "B"} {
@@ -763,7 +763,7 @@ func TestSelectOutput_Resume_TieToWinner_CleansStaleTiedOutputs(t *testing.T) {
 		Votes:  map[string]int{"A": 2, "B": 0},
 		Winner: "A",
 	}
-	if _, err := SelectOutput(s, result, r2); err != nil {
+	if _, err := SelectOutput(s, result, r2, nil); err != nil {
 		t.Fatalf("SelectOutput: %v", err)
 	}
 	body, err := os.ReadFile(filepath.Join(s.Path, "output.md"))
@@ -800,7 +800,7 @@ func TestSelectOutput_Resume_WinnerToTie_CleansStaleOutputMd(t *testing.T) {
 		Votes:          map[string]int{"A": 1, "B": 1},
 		TiedCandidates: []string{"A", "B"},
 	}
-	if _, err := SelectOutput(s, result, r2); err != nil {
+	if _, err := SelectOutput(s, result, r2, nil); err != nil {
 		t.Fatalf("SelectOutput: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(s.Path, "output.md")); !os.IsNotExist(err) {
@@ -841,7 +841,7 @@ func TestSelectOutput_Resume_TiedSetShrinks_CleansDroppedLabel(t *testing.T) {
 		Votes:          map[string]int{"A": 1, "B": 1, "C": 0},
 		TiedCandidates: []string{"A", "B"},
 	}
-	if _, err := SelectOutput(s, result, r2); err != nil {
+	if _, err := SelectOutput(s, result, r2, nil); err != nil {
 		t.Fatalf("SelectOutput: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(s.Path, "output-C.md")); !os.IsNotExist(err) {
@@ -898,13 +898,13 @@ func TestSelectOutput_MissingR2ForWinner_Error(t *testing.T) {
 		fn:   func(ctx context.Context, req executor.Request, _ int) (string, error) { return "", nil },
 	})
 	result := TallyResult{Winner: "X", Votes: map[string]int{"X": 1}}
-	if _, err := SelectOutput(s, result, []RoundOutput{{Label: "A"}}); err == nil {
+	if _, err := SelectOutput(s, result, []RoundOutput{{Label: "A"}}, nil); err == nil {
 		t.Fatal("expected error when winner label has no R2 output")
 	}
 }
 
 func TestSelectOutput_NilSession(t *testing.T) {
-	if _, err := SelectOutput(nil, TallyResult{Winner: "A"}, []RoundOutput{{Label: "A", Body: "x"}}); err == nil {
+	if _, err := SelectOutput(nil, TallyResult{Winner: "A"}, []RoundOutput{{Label: "A", Body: "x"}}, nil); err == nil {
 		t.Fatal("expected error for nil session")
 	}
 }
@@ -934,7 +934,7 @@ func TestSelectOutput_UniqueWinner_ExtractsCleanAnswer(t *testing.T) {
 		Votes:  map[string]int{"A": 0, "B": 3, "C": 0},
 		Winner: "B",
 	}
-	outcome, err := SelectOutput(s, result, r2)
+	outcome, err := SelectOutput(s, result, r2, nil)
 	if err != nil {
 		t.Fatalf("SelectOutput: %v", err)
 	}
@@ -977,7 +977,7 @@ func TestSelectOutput_UniqueWinner_NoJSONTail_FallsBackToRawR2(t *testing.T) {
 		{Label: "A", Participation: "ok", Body: winnerBody},
 	}
 	result := TallyResult{Votes: map[string]int{"A": 1}, Winner: "A"}
-	outcome, err := SelectOutput(s, result, r2)
+	outcome, err := SelectOutput(s, result, r2, nil)
 	if err != nil {
 		t.Fatalf("SelectOutput: %v", err)
 	}
@@ -1012,7 +1012,7 @@ func TestSelectOutput_UniqueWinner_MalformedJSON_FallsBackToRawR2(t *testing.T) 
 		{Label: "A", Participation: "ok", Body: winnerBody},
 	}
 	result := TallyResult{Votes: map[string]int{"A": 1}, Winner: "A"}
-	outcome, err := SelectOutput(s, result, r2)
+	outcome, err := SelectOutput(s, result, r2, nil)
 	if err != nil {
 		t.Fatalf("SelectOutput: %v", err)
 	}
@@ -1050,7 +1050,7 @@ func TestSelectOutput_Tie_NoExtractionPerformed(t *testing.T) {
 		Votes:          map[string]int{"A": 1, "B": 1},
 		TiedCandidates: []string{"A", "B"},
 	}
-	outcome, err := SelectOutput(s, result, r2)
+	outcome, err := SelectOutput(s, result, r2, nil)
 	if err != nil {
 		t.Fatalf("SelectOutput: %v", err)
 	}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -227,9 +227,15 @@ func Run(ctx context.Context, profile *config.Profile, question string, sess *se
 	// Unique winner: mirror what SelectOutput wrote to output.md into
 	// v.Answer so cmd/council prints the same bytes to stdout. On the
 	// extraction-OK path that is the clean JSON-tail answer; on any
-	// fallback it is the raw R2 body verbatim.
+	// fallback it is the raw R2 body verbatim. AnswerExtraction (ADR-0014)
+	// records which path was taken so an operator can audit parse-success
+	// rates across sessions without re-reading every R2 body.
 	if tally.Winner != "" {
 		v.Answer = outcome.Answer
+		v.AnswerExtraction = &session.AnswerExtraction{
+			Status:      outcome.Status.VerdictStatus(),
+			WinnerLabel: outcome.WinnerLabel,
+		}
 		v.Status = "ok"
 		return finalizeAndWrite(v, sess, startedAt, nil)
 	}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -217,7 +217,7 @@ func Run(ctx context.Context, profile *config.Profile, question string, sess *se
 	}
 
 	tally := debate.Tally(ballots, activeLabels)
-	outcome, err := debate.SelectOutput(sess, tally, r2)
+	outcome, err := debate.SelectOutput(sess, tally, r2, reporter)
 	if err != nil {
 		v.Status = "error"
 		return finalizeAndWrite(v, sess, startedAt, err)

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -217,21 +217,19 @@ func Run(ctx context.Context, profile *config.Profile, question string, sess *se
 	}
 
 	tally := debate.Tally(ballots, activeLabels)
-	if err := debate.SelectOutput(sess, tally, r2); err != nil {
+	outcome, err := debate.SelectOutput(sess, tally, r2)
+	if err != nil {
 		v.Status = "error"
 		return finalizeAndWrite(v, sess, startedAt, err)
 	}
 	v.Voting = buildVotingVerdict(tally)
 
-	// Unique winner: copy winner's R2 body into v.Answer so cmd/council
-	// can print it to stdout.
+	// Unique winner: mirror what SelectOutput wrote to output.md into
+	// v.Answer so cmd/council prints the same bytes to stdout. On the
+	// extraction-OK path that is the clean JSON-tail answer; on any
+	// fallback it is the raw R2 body verbatim.
 	if tally.Winner != "" {
-		for _, o := range r2 {
-			if o.Label == tally.Winner {
-				v.Answer = o.Body
-				break
-			}
-		}
+		v.Answer = outcome.Answer
 		v.Status = "ok"
 		return finalizeAndWrite(v, sess, startedAt, nil)
 	}

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -214,6 +214,19 @@ func TestRun_HappyPath_V2(t *testing.T) {
 	if got := len(v.Anonymization); got != 3 {
 		t.Errorf("anonymization size = %d, want 3", got)
 	}
+	// AnswerExtraction (ADR-0014) reports the unique-winner outcome. The
+	// stub body has no JSON tail so the orchestrator must record a
+	// fallback status alongside the winning label — never nil on a
+	// unique-winner verdict.
+	if v.AnswerExtraction == nil {
+		t.Fatal("AnswerExtraction nil on unique-winner verdict")
+	}
+	if v.AnswerExtraction.Status != "fallback_no_json" {
+		t.Errorf("AnswerExtraction.Status = %q, want fallback_no_json (raw stub body has no JSON tail)", v.AnswerExtraction.Status)
+	}
+	if v.AnswerExtraction.WinnerLabel != "A" {
+		t.Errorf("AnswerExtraction.WinnerLabel = %q, want A", v.AnswerExtraction.WinnerLabel)
+	}
 }
 
 // TestRun_R1Drop_V2 — one expert fails R1. Quorum=1 still met so the run
@@ -345,6 +358,81 @@ func TestRun_TieNoConsensus_V2(t *testing.T) {
 	// must not pick it up.
 	if _, err := os.Stat(filepath.Join(s.Path, ".done")); err != nil {
 		t.Errorf("root .done missing on tie: %v", err)
+	}
+	// AnswerExtraction is unique-winner-only (ADR-0014); ties leave it
+	// nil so the verdict.json key is omitted via `omitempty`.
+	if v.AnswerExtraction != nil {
+		t.Errorf("AnswerExtraction = %+v, want nil on tie (no extraction performed)", v.AnswerExtraction)
+	}
+}
+
+// TestRun_AnswerExtraction_OK drives a winner whose R2 ends with a
+// JSON-tail block carrying a clean answer. Run must publish that extracted
+// answer (not the raw R2) into v.Answer + output.md and record
+// v.AnswerExtraction.Status == "ok" so the operator-facing audit field
+// matches the bytes on disk (ADR-0014).
+func TestRun_AnswerExtraction_OK(t *testing.T) {
+	const cleanAnswer = "Use Raft. It is simpler and well-documented."
+	const r2Body = "Эксперт A корректно указывает на сложность Paxos.\n\n" +
+		"```json\n" +
+		`{"answer": "Use Raft. It is simpler and well-documented."}` + "\n" +
+		"```\n"
+	stub := &stubExec{
+		name: "stub",
+		on: func(ctx context.Context, n int64, req executor.Request) (executor.Response, error) {
+			stage, label := classifyRequest(req)
+			switch stage {
+			case stageBallot:
+				return writeOK("VOTE: A\n")(ctx, n, req)
+			case stageR1:
+				return writeOK("body-"+label)(ctx, n, req)
+			case stageR2:
+				return writeOK(r2Body)(ctx, n, req)
+			}
+			t.Errorf("unclassified stub call: %s", req.StdoutFile)
+			return executor.Response{}, errors.New("unclassified")
+		},
+	}
+	register(t, stub)
+
+	p := newV2TestProfile("stub", []string{"e1", "e2", "e3"})
+	s := newV2Session(t, p, "Raft or Paxos?")
+
+	v, err := Run(context.Background(), p, "Raft or Paxos?", s, debate.NopReporter{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if v.Status != "ok" {
+		t.Fatalf("status = %q, want ok", v.Status)
+	}
+	if v.AnswerExtraction == nil {
+		t.Fatal("AnswerExtraction nil, want populated")
+	}
+	if v.AnswerExtraction.Status != "ok" {
+		t.Errorf("AnswerExtraction.Status = %q, want ok", v.AnswerExtraction.Status)
+	}
+	if v.AnswerExtraction.WinnerLabel != "A" {
+		t.Errorf("AnswerExtraction.WinnerLabel = %q, want A", v.AnswerExtraction.WinnerLabel)
+	}
+	want := cleanAnswer + "\n"
+	if v.Answer != want {
+		t.Errorf("v.Answer = %q, want %q (extracted JSON tail, not raw R2)", v.Answer, want)
+	}
+	out, err := os.ReadFile(filepath.Join(s.Path, "output.md"))
+	if err != nil {
+		t.Fatalf("read output.md: %v", err)
+	}
+	if string(out) != want {
+		t.Errorf("output.md = %q, want %q", out, want)
+	}
+	// Raw R2 stays under rounds/2/experts/A/output.md verbatim — extraction
+	// must never touch the audit record.
+	rawR2, err := os.ReadFile(filepath.Join(s.Path, "rounds", "2", "experts", "A", "output.md"))
+	if err != nil {
+		t.Fatalf("read rounds/2 output.md: %v", err)
+	}
+	if string(rawR2) != r2Body {
+		t.Errorf("rounds/2 R2 body mutated: got %q, want %q", rawR2, r2Body)
 	}
 }
 

--- a/pkg/session/testdata/verdict_canonical.json
+++ b/pkg/session/testdata/verdict_canonical.json
@@ -129,6 +129,10 @@
       }
     ]
   },
+  "answer_extraction": {
+    "status": "ok",
+    "winner_label": "A"
+  },
   "started_at": "2026-04-22T10:14:30Z",
   "ended_at": "2026-04-22T10:15:28Z",
   "duration_seconds": 58.2

--- a/pkg/session/verdict.go
+++ b/pkg/session/verdict.go
@@ -13,22 +13,45 @@ import (
 // verdict.json at session end. Field order, JSON tags, and types gate the
 // v2 schema contract in docs/design/v2.md §6 (fitness functions F3/F7/F8/F12).
 // The bytes-exact snapshot test in verdict_test.go locks this shape.
+//
+// AnswerExtraction (ADR-0014) records what SelectOutput wrote to output.md
+// on the unique-winner path: status="ok" when the JSON-tail extractor found
+// a clean answer, or status="fallback_*" when the orchestrator fell back to
+// writing the raw R2 body. Omitted on ties (no winner) and on runs where
+// SelectOutput did not run (quorum failure, injection rejection, interrupt
+// before voting). Additive field — consumers that predate ADR-0014 ignore
+// unknown keys and continue to read the published answer from
+// verdict.answer / output.md.
 type Verdict struct {
-	Version         int               `json:"version"`
-	SessionID       string            `json:"session_id"`
-	SessionPath     string            `json:"session_path"`
-	Profile         string            `json:"profile"`
-	Question        string            `json:"question"`
-	Answer          string            `json:"answer"`
-	Status          string            `json:"status"`
-	Anonymization   map[string]string `json:"anonymization,omitempty"`
-	Rounds          []Round           `json:"rounds"`
-	Experts         []ExpertSummary   `json:"experts"`
-	Voting          *VerdictVoting    `json:"voting,omitempty"`
-	RateLimits      []RateLimitEntry  `json:"rate_limits,omitempty"`
-	StartedAt       string            `json:"started_at"`
-	EndedAt         string            `json:"ended_at"`
-	DurationSeconds float64           `json:"duration_seconds"`
+	Version          int               `json:"version"`
+	SessionID        string            `json:"session_id"`
+	SessionPath      string            `json:"session_path"`
+	Profile          string            `json:"profile"`
+	Question         string            `json:"question"`
+	Answer           string            `json:"answer"`
+	Status           string            `json:"status"`
+	Anonymization    map[string]string `json:"anonymization,omitempty"`
+	Rounds           []Round           `json:"rounds"`
+	Experts          []ExpertSummary   `json:"experts"`
+	Voting           *VerdictVoting    `json:"voting,omitempty"`
+	AnswerExtraction *AnswerExtraction `json:"answer_extraction,omitempty"`
+	RateLimits       []RateLimitEntry  `json:"rate_limits,omitempty"`
+	StartedAt        string            `json:"started_at"`
+	EndedAt          string            `json:"ended_at"`
+	DurationSeconds  float64           `json:"duration_seconds"`
+}
+
+// AnswerExtraction is the per-run record of how output.md / verdict.answer
+// was produced from the winner's R2 body (ADR-0014). Status is one of
+// "ok" | "fallback_no_json" | "fallback_invalid_json" |
+// "fallback_missing_answer" | "fallback_empty_answer". WinnerLabel is the
+// anonymized single-letter token of the winning expert. The struct is
+// pointer-typed and `omitempty` on Verdict so resumed sessions that predate
+// the field — and ties / non-voting terminal paths where extraction never
+// ran — serialize cleanly with no answer_extraction key.
+type AnswerExtraction struct {
+	Status      string `json:"status"`
+	WinnerLabel string `json:"winner_label"`
 }
 
 // RateLimitEntry records one expert subprocess that returned a runner-level

--- a/pkg/session/verdict_test.go
+++ b/pkg/session/verdict_test.go
@@ -60,6 +60,10 @@ func canonicalVerdict() *Verdict {
 				{VoterLabel: "C", VotedFor: "C"},
 			},
 		},
+		AnswerExtraction: &AnswerExtraction{
+			Status:      "ok",
+			WinnerLabel: "A",
+		},
 		StartedAt:       "2026-04-22T10:14:30Z",
 		EndedAt:         "2026-04-22T10:15:28Z",
 		DurationSeconds: 58.2,
@@ -325,6 +329,67 @@ func TestVerdict_RateLimitsRoundTrip(t *testing.T) {
 	}
 	if first["executor"] != "codex" {
 		t.Errorf("rate_limits[0].executor = %v, want codex", first["executor"])
+	}
+}
+
+// TestVerdict_AnswerExtractionOmittedWhenNil pins the omitempty contract
+// on AnswerExtraction so resumed sessions that predate ADR-0014 — and ties
+// / non-voting terminal paths where SelectOutput never ran — serialize
+// without the answer_extraction key. The canonical fixture sets it; this
+// test takes a copy with the pointer cleared to assert the JSON key
+// disappears.
+func TestVerdict_AnswerExtractionOmittedWhenNil(t *testing.T) {
+	v := canonicalVerdict()
+	v.AnswerExtraction = nil
+	buf, err := marshalVerdict(v)
+	if err != nil {
+		t.Fatalf("marshalVerdict: %v", err)
+	}
+	if strings.Contains(string(buf), "answer_extraction") {
+		t.Errorf("answer_extraction key present when AnswerExtraction is nil:\n%s", buf)
+	}
+}
+
+// TestVerdict_AnswerExtractionWireShape pins the wire shape of every
+// AnswerExtraction status the orchestrator can produce. verdict.json must
+// carry status="ok" on extraction success and "fallback_<reason>" on every
+// fail-closed path so the ADR-0014 fitness probe (`.answer_extraction.status
+// == "ok" or (.answer_extraction.status | startswith("fallback_"))`) holds
+// across every session. winner_label is always present alongside.
+func TestVerdict_AnswerExtractionWireShape(t *testing.T) {
+	cases := []struct {
+		name   string
+		status string
+	}{
+		{name: "ok", status: "ok"},
+		{name: "fallback_no_json", status: "fallback_no_json"},
+		{name: "fallback_invalid_json", status: "fallback_invalid_json"},
+		{name: "fallback_missing_answer", status: "fallback_missing_answer"},
+		{name: "fallback_empty_answer", status: "fallback_empty_answer"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := canonicalVerdict()
+			v.AnswerExtraction = &AnswerExtraction{Status: tc.status, WinnerLabel: "B"}
+			buf, err := marshalVerdict(v)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var generic map[string]any
+			if err := json.Unmarshal(buf, &generic); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			ae, ok := generic["answer_extraction"].(map[string]any)
+			if !ok {
+				t.Fatalf("answer_extraction missing or not an object; got %T", generic["answer_extraction"])
+			}
+			if got := ae["status"]; got != tc.status {
+				t.Errorf("status = %v, want %q", got, tc.status)
+			}
+			if got := ae["winner_label"]; got != "B" {
+				t.Errorf("winner_label = %v, want B", got)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Closes [#16](https://github.com/fitz123/council/issues/16). The published answer in `verdict.answer` and `output.md` no longer carries debate meta-commentary about other experts. The winner's R2 response now ends with a fenced JSON block containing a clean `answer` and `citations[]`; the orchestrator extracts that field and writes it as the published answer. Raw R2 stays in `rounds/r2/<label>.txt` for audit, and on any extraction failure the output falls back to the raw R2 — strictly today's behavior, no regression.
- "Option A done right" per the council session at `.council/sessions/2026-04-27T21-24-13Z-pleasantly-above-maggot/`. JSON is materially more reliable than the original `--- ANSWER ---` text marker, and the failure mode is fail-closed instead of fail-open. Zero extra LLM calls and zero added latency vs. the council's headline B + validation pick.
- New: `defaults/prompts/peer-aware.md` JSON-tail discipline; `pkg/debate/extract.go` + table-driven tests covering all five fail-closed paths; `SelectOutput` integration; `verdict.json.answer_extraction` metadata field; verbose-stream event for the extraction outcome; ADR-0014.

## Test plan

- [ ] `go test ./...` — full suite passes
- [ ] `go vet ./...` — clean
- [ ] `go test -cover ./pkg/debate/` — `extract.go` coverage ≥ 90%
- [ ] Manual smoke: run `council` against a real question and confirm `output.md` is clean (no "Эксперт A/B/C" / "Expert A/B/C" references on success path)
- [ ] Compare `output.md` vs. `rounds/r2/<winner>.txt` on the smoke run — confirm citations preserved in the answer field
- [ ] `verdict.json.answer_extraction.status` is one of `ok | fallback_no_json | fallback_invalid_json | fallback_missing_answer | fallback_empty_answer` on the smoke run
- [ ] `--verbose` stderr shows the extraction event line on the smoke run

🤖 Generated with [Claude Code](https://claude.com/claude-code)